### PR TITLE
Main slider reworks ate

### DIFF
--- a/Zero_Interface-Loader.alp
+++ b/Zero_Interface-Loader.alp
@@ -35328,7 +35328,12 @@ else{
 	
 	//Determine heatdemand
 	heatDemand = new J_EAConsumption(parentGC, OL_EnergyAssetType.HEAT_DEMAND, profileName, 0.0, yearlyDemandHeat_kWh, 0.0, 0.0, 0.0, energyModel.p_timeStep_h, null);
-	maxPowerGasburner = yearlyDemandHeat_kWh*genericProfiles_data.buildingHeatDemandList_maximum();//(yearlyDemandHeat_kWh / 8760 * 10);
+	if(genericProfiles_data.buildingHeatDemandList_maximum() != null){
+		maxPowerGasburner = yearlyDemandHeat_kWh*genericProfiles_data.buildingHeatDemandList_maximum();
+	}
+	else{
+		maxPowerGasburner = yearlyDemandHeat_kWh / 8760 * 10;
+	}
 }
 
 //Initialize parameters

--- a/Zero_Interface-Loader.alp
+++ b/Zero_Interface-Loader.alp
@@ -4,7 +4,7 @@
 	         AnyLogic Project File
 *************************************************
 -->
-<AnyLogicWorkspace WorkspaceVersion="1.9" AnyLogicVersion="8.9.1.202408021045" AlpVersion="8.9.1">
+<AnyLogicWorkspace WorkspaceVersion="1.9" AnyLogicVersion="8.9.1.202408021042" AlpVersion="8.9.1">
 <Model>
 	<Id>1658477103134</Id>
 	<Name><![CDATA[Zero_Interface-Loader]]></Name>
@@ -1749,7 +1749,7 @@ import com.anylogic.engine.markup.GISPoint;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1715178022675</Id>
 					<Name><![CDATA[c_orderedVehicles]]></Name>
-					<X>68</X><Y>-570</Y>
+					<X>68</X><Y>-550</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -1764,7 +1764,7 @@ import com.anylogic.engine.markup.GISPoint;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1715183417595</Id>
 					<Name><![CDATA[c_orderedHeatingSystemsCompanies]]></Name>
-					<X>68</X><Y>-545</Y>
+					<X>68</X><Y>-525</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -1779,7 +1779,7 @@ import com.anylogic.engine.markup.GISPoint;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1715183423011</Id>
 					<Name><![CDATA[c_orderedPVSystems]]></Name>
-					<X>68</X><Y>-590</Y>
+					<X>68</X><Y>-570</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -1794,7 +1794,7 @@ import com.anylogic.engine.markup.GISPoint;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1719176257019</Id>
 					<Name><![CDATA[c_orderedHeatingSystemsHouses]]></Name>
-					<X>68</X><Y>-525</Y>
+					<X>68</X><Y>-505</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -1809,7 +1809,7 @@ import com.anylogic.engine.markup.GISPoint;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1720174179054</Id>
 					<Name><![CDATA[c_orderedHousesPrivateParking]]></Name>
-					<X>70</X><Y>-490</Y>
+					<X>70</X><Y>-470</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -1824,7 +1824,7 @@ import com.anylogic.engine.markup.GISPoint;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1720174197464</Id>
 					<Name><![CDATA[c_orderedHousesPublicParking]]></Name>
-					<X>70</X><Y>-470</Y>
+					<X>70</X><Y>-450</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -1839,7 +1839,7 @@ import com.anylogic.engine.markup.GISPoint;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1720376141906</Id>
 					<Name><![CDATA[c_activePublicChargers]]></Name>
-					<X>70</X><Y>-400</Y>
+					<X>70</X><Y>-380</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -1854,7 +1854,7 @@ import com.anylogic.engine.markup.GISPoint;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1720376165741</Id>
 					<Name><![CDATA[c_inactivePublicChargers]]></Name>
-					<X>70</X><Y>-380</Y>
+					<X>70</X><Y>-360</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -1869,7 +1869,7 @@ import com.anylogic.engine.markup.GISPoint;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1720376624239</Id>
 					<Name><![CDATA[c_fixedPublicChargers]]></Name>
-					<X>70</X><Y>-420</Y>
+					<X>70</X><Y>-400</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -2588,7 +2588,7 @@ f_setUIButton();
 //f_listFunctions();
 ]]></Body>
 				</Function>
-				<Function AccessType="default" StaticFunction="false">
+				<Function AccessType="protected" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1707918668165</Id>
@@ -2697,12 +2697,6 @@ while (v_connectionOwnerIndexNr < c_COCompanies.size()){
 		companyUI.c_additionalVehicles.put(GC, new ArrayList<J_EAVehicle>());
 	}
 	
-	/*
-	for (GridConnection GC : companyUI.c_ownedGridConnections) {
-		companyUI.c_ownedBuildings.addAll(GC.c_connectedGISObjects);
-	}
-	*/
-	
 	companyUI.p_amountOfBuildings = companyUI.c_ownedBuildings.size();
 	companyUI.c_subTenants = COC.c_subTenants;
 	
@@ -2715,22 +2709,6 @@ while (v_connectionOwnerIndexNr < c_COCompanies.size()){
 			companyUI.p_companyName = companyUI.c_ownedBuildings.get(0).p_annotation;
 		}
 	}
-	
-	/*
-	//Add connected trafos for each GC
-	for (int j = 0; j < companyUI.c_ownedGridConnections.size() ; j++){
-		companyUI.c_connectedTrafos.add(COC.f_getOwnedGridConnections().get(j).p_parentNodeElectricID);
-	}
-	
-	//Add scenario settings for each GC
-	for (int k = 0; k < companyUI.c_ownedGridConnections.size() ; k++){
-		companyUI.c_scenarioSettings_Current.add(c_scenarioMap_Current.get(companyUI.c_ownedGridConnections.get(k)));
-		companyUI.c_scenarioSettings_Future.add(c_scenarioMap_Future.get(companyUI.c_ownedGridConnections.get(k)));
-	}
-	*/
-	
-
-
 
 	//Initialize the companyUI
 	companyUI.f_initializeCompanyUI();
@@ -2746,6 +2724,11 @@ while (v_connectionOwnerIndexNr < c_COCompanies.size()){
 
 v_connectionOwnerIndexNr = 0;
 
+//Get the ghost vehicles for the transport slider tab
+uI_Tabs.pop_tabMobility.get(0).f_getNumberOfGhostVehicles();
+
+//Get the ghost heating systems
+uI_Tabs.pop_tabHeating.get(0).f_getNumberOfGhostHeatingSystems();
 ]]></Body>
 				</Function>
 				<Function AccessType="public" StaticFunction="false">
@@ -2869,7 +2852,7 @@ mainArea.v_dataNetbelastingDuurkrommeWeekday_kW = energyModel.data_weekdayNetbel
 
 uI_Results.v_gridConnection = uI_Results.add_pop_areaResults(OL_GISObjectType.BUILDING, "GC");
 uI_Results.v_trafo = uI_Results.add_pop_areaResults(OL_GISObjectType.GRIDNODE, "GN");
-uI_Results.v_collective = uI_Results.add_pop_areaResults();
+//uI_Results.v_collective = uI_Results.add_pop_areaResults(AreaTypes.COLLECTIVE);
 
 //uI_Results.energyModel = energyModel;
 uI_Results.f_initialize();
@@ -3528,7 +3511,10 @@ ArrayList<GridConnection> otherGCs = GCs.stream().filter(gc -> !gc.v_hasPV).coll
 //traceln("amount of GCs with PV at start: " + GCsWithPV.size());
 //traceln("amount of other GCs at start: " + otherGCs.size());
 
-otherGCs.addAll(GCsWithPV);
+if(c_companyUIs.size() == 0){
+	otherGCs.addAll(GCsWithPV);
+}
+
 c_orderedPVSystems = otherGCs;]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
@@ -3542,7 +3528,7 @@ c_orderedPVSystems = otherGCs;]]></Body>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Body><![CDATA[// First we make a copy of all the vehicle energy assets
-List<J_EA> EAs = new ArrayList<>(energyModel.f_getEnergyAssets());
+List<J_EA> EAs = new ArrayList<>(findAll(energyModel.f_getEnergyAssets(), ea -> !(ea.getParentAgent() instanceof GCPublicCharger)));
 EAs = EAs.stream().filter(ea -> ea instanceof J_EAVehicle).collect(Collectors.toList());
 // Find all the EVs at the start of the simulation
 ArrayList<J_EA> EAEVs = EAs.stream().filter(ea -> (ea instanceof J_EAEV)).collect(Collectors.toCollection(ArrayList::new));
@@ -3552,7 +3538,10 @@ ArrayList<J_EA> otherEAs = EAs.stream().filter(ea -> !(ea instanceof J_EAEV)).co
 //traceln("amount of EVs at start: " + EAEVs.size());
 //traceln("amount of other EAs at start: " + otherEAs.size());
 
-otherEAs.addAll(EAEVs);
+if(c_companyUIs.size() == 0){ // Dont add the ev to the pool if there are companyUIs
+	otherEAs.addAll(EAEVs);
+}
+
 c_orderedVehicles = otherEAs;]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
@@ -3567,13 +3556,15 @@ c_orderedVehicles = otherEAs;]]></Body>
 					<ShowLabel>true</ShowLabel>
 					<Body><![CDATA[// First we make a copy of all the GridConnections
 List<GridConnection> companyList = new ArrayList<>(energyModel.f_getGridConnections());
-companyList = companyList.stream().filter(gc -> gc instanceof GCUtility).collect(Collectors.toList());
+companyList = companyList.stream().filter(gc -> gc instanceof GCUtility && gc.p_primaryHeatingAsset != null).collect(Collectors.toList());
 
 // Find all the GCs with Heatpumps at the start of the simulation
 ArrayList<GridConnection> GCsWithHP = companyList.stream().filter(gc -> gc.p_primaryHeatingAsset instanceof J_EAConversionHeatPump).collect(Collectors.toCollection(ArrayList::new));
 ArrayList<GridConnection> otherGCs = companyList.stream().filter(gc -> !(gc.p_primaryHeatingAsset instanceof J_EAConversionHeatPump)).collect(Collectors.toCollection(ArrayList::new));
-// We make sure that the GCs with Heatpumps at the start of the simulation are the last in the list
-otherGCs.addAll(GCsWithHP);
+// We make sure that the GCs with Heatpumps at the start of the simulation are the last in the list (if there is no companyUI)
+if(c_companyUIs.size() == 0){
+	otherGCs.addAll(GCsWithHP);
+}
 c_orderedHeatingSystemsCompanies = otherGCs;
 
 
@@ -3598,7 +3589,7 @@ c_orderedHeatingSystemsHouses = otherHouses;]]></Body>
 					<Body><![CDATA[f_initialElectricVehiclesOrder();
 f_initialPVSystemsOrder();
 f_initialHeatingSystemsOrder();
-//f_setSliderRanges();
+f_projectSpecificOrderedCollectionAdjustments();
 
 ]]></Body>
 				</Function>
@@ -3744,7 +3735,7 @@ if(settings.showKPISummary() == null || !settings.showKPISummary()){
 					<Body><![CDATA[GISRegion gisregion = new GISRegion(map, gisTokens);
 return gisregion;]]></Body>
 				</Function>
-				<Function AccessType="protected" StaticFunction="false">
+				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1715869498509</Id>
@@ -3871,14 +3862,21 @@ gis_area.f_style( rect_householdNoProduction.getFillColor(), null, null, null );
 					<ShowLabel>true</ShowLabel>
 					<Body><![CDATA[// ATTENTION: If you have custom tabs it may be neccesary to override this function and add updates to your custom sliders!
 
+if(c_companyUIs.size()>0){//Update ghost vehicles and heating systems present if there are companyUIs
+	uI_Tabs.pop_tabHeating.get(0).f_getNumberOfGhostHeatingSystems();
+	uI_Tabs.pop_tabMobility.get(0).f_getNumberOfGhostVehicles();
+}
+
+
+
 // PV SYSTEMS:
-double PVsystems = count(energyModel.UtilityConnections, x->x.v_hasPV == true);		
-int PV_pct = roundToInt(100 * PVsystems / energyModel.UtilityConnections.size());
+double PVsystems = count(energyModel.UtilityConnections, x->x.v_hasPV == true && x.v_isActive);		
+int PV_pct = roundToInt(100 * PVsystems / count(energyModel.UtilityConnections, x->x.v_isActive));
 uI_Tabs.pop_tabElectricity.get(0).getSliderRooftopPVCompanies_pct().setValue(PV_pct, false);
 
 // GAS_BURNER / HEATING SYSTEMS: // Still a slight error. GasBurners + HeatPumps != total, because some GC have primary heating asset null
-int GasBurners = count(energyModel.UtilityConnections, gc->gc.p_primaryHeatingAsset instanceof J_EAConversionGasBurner);
-int GasBurners_pct = roundToInt(100 * GasBurners / energyModel.UtilityConnections.size());
+int GasBurners = count(energyModel.UtilityConnections, gc->gc.p_primaryHeatingAsset instanceof J_EAConversionGasBurner && gc.v_isActive);
+int GasBurners_pct = roundToInt(100.0 * GasBurners / (count(energyModel.UtilityConnections, x -> x.v_isActive && x.p_primaryHeatingAsset != null) + uI_Tabs.pop_tabHeating.get(0).v_totalNumberOfGhostHeatingSystems_ElectricHeatpumps + uI_Tabs.pop_tabHeating.get(0).v_totalNumberOfGhostHeatingSystems_HybridHeatpumps));
 
 uI_Tabs.pop_tabHeating.get(0).getSliderGasBurnerCompanies_pct().setValue(GasBurners_pct, false);
 uI_Tabs.pop_tabHeating.get(0).f_setHeatingSliders( 0, uI_Tabs.pop_tabHeating.get(0).getSliderGasBurnerCompanies_pct(), uI_Tabs.pop_tabHeating.get(0).getSliderElectricHeatPumpCompanies_pct(), null, null );
@@ -3895,29 +3893,32 @@ uI_Tabs.pop_tabHeating.get(0).f_setHeatingSliders( 0, uI_Tabs.pop_tabHeating.get
 	
 // TRUCKS:
 int DieselTrucks = 0;
-int ElectricTrucks = 0;
+int ElectricTrucks = uI_Tabs.pop_tabMobility.get(0).v_totalNumberOfGhostVehicle_Trucks;
 int HydrogenTrucks = 0;
 for (GCUtility gc : energyModel.UtilityConnections) {
-	for (J_EAVehicle vehicle : gc.c_vehicleAssets) {
-		if (vehicle instanceof J_EADieselVehicle && vehicle.getEAType() == OL_EnergyAssetType.DIESEL_TRUCK) {
-			DieselTrucks += 1;
-		}
-		else if (vehicle instanceof J_EAEV && vehicle.getEAType() == OL_EnergyAssetType.ELECTRIC_TRUCK) {
-			ElectricTrucks += 1;
-		}
-		else if (vehicle instanceof J_EAHydrogenVehicle && vehicle.getEAType() == OL_EnergyAssetType.HYDROGEN_TRUCK) {
-			HydrogenTrucks += 1;
+	if(gc.v_isActive){
+		for (J_EAVehicle vehicle : gc.c_vehicleAssets) {
+			if (vehicle instanceof J_EADieselVehicle && vehicle.getEAType() == OL_EnergyAssetType.DIESEL_TRUCK) {
+				DieselTrucks += 1;
+			}
+			else if (vehicle instanceof J_EAEV && vehicle.getEAType() == OL_EnergyAssetType.ELECTRIC_TRUCK) {
+				ElectricTrucks += 1;
+			}
+			else if (vehicle instanceof J_EAHydrogenVehicle && vehicle.getEAType() == OL_EnergyAssetType.HYDROGEN_TRUCK) {
+				HydrogenTrucks += 1;
+			}
 		}
 	}
 }
+
 int totalTrucks = DieselTrucks + ElectricTrucks + HydrogenTrucks;
 int DieselTrucks_pct = 100;
 int ElectricTrucks_pct = 0;
 int HydrogenTrucks_pct = 0;
 if (totalTrucks != 0) {
-	DieselTrucks_pct = roundToInt(100 * DieselTrucks / totalTrucks);
-	ElectricTrucks_pct = roundToInt(100 * ElectricTrucks / totalTrucks);
-	HydrogenTrucks_pct = roundToInt(100 * HydrogenTrucks / totalTrucks);
+	DieselTrucks_pct = roundToInt(100.0 * DieselTrucks / totalTrucks);
+	ElectricTrucks_pct = roundToInt(100.0 * ElectricTrucks / totalTrucks);
+	HydrogenTrucks_pct = roundToInt(100.0 * HydrogenTrucks / totalTrucks);
 }
 uI_Tabs.pop_tabMobility.get(0).getSliderFossilFuelTrucks_pct().setValue(DieselTrucks_pct, false);
 uI_Tabs.pop_tabMobility.get(0).getSliderElectricTrucks_pct().setValue(ElectricTrucks_pct, false);
@@ -3925,29 +3926,32 @@ uI_Tabs.pop_tabMobility.get(0).getSliderHydrogenTrucks_pct().setValue(HydrogenTr
 
 // VANS:
 int DieselVans = 0;
-int ElectricVans = 0;
+int ElectricVans = uI_Tabs.pop_tabMobility.get(0).v_totalNumberOfGhostVehicle_Vans;
 int HydrogenVans = 0;
 for (GCUtility gc : energyModel.UtilityConnections) {
-	for (J_EAVehicle vehicle : gc.c_vehicleAssets) {
-		if (vehicle instanceof J_EADieselVehicle && vehicle.getEAType() == OL_EnergyAssetType.DIESEL_VAN) {
-			DieselVans += 1;
-		}
-		else if (vehicle instanceof J_EAEV && vehicle.getEAType() == OL_EnergyAssetType.ELECTRIC_VAN) {
-			ElectricVans += 1;
-		}
-		else if (vehicle instanceof J_EAHydrogenVehicle && vehicle.getEAType() == OL_EnergyAssetType.HYDROGEN_VAN) {
-			HydrogenVans += 1;
+	if(gc.v_isActive){
+		for (J_EAVehicle vehicle : gc.c_vehicleAssets) {
+			if (vehicle instanceof J_EADieselVehicle && vehicle.getEAType() == OL_EnergyAssetType.DIESEL_VAN) {
+				DieselVans += 1;
+			}
+			else if (vehicle instanceof J_EAEV && vehicle.getEAType() == OL_EnergyAssetType.ELECTRIC_VAN) {
+				ElectricVans += 1;
+			}
+			else if (vehicle instanceof J_EAHydrogenVehicle && vehicle.getEAType() == OL_EnergyAssetType.HYDROGEN_VAN) {
+				HydrogenVans += 1;
+			}
 		}
 	}
 }
+
 int totalVans = DieselVans + ElectricVans + HydrogenVans;
 int DieselVans_pct = 100;
 int ElectricVans_pct = 0;
 int HydrogenVans_pct = 0;
 if (totalVans != 0) {
-	DieselVans_pct = roundToInt(100 * DieselVans / totalVans);
-	ElectricVans_pct = roundToInt(100 * ElectricVans / totalVans);
-	HydrogenVans_pct = roundToInt(100 * HydrogenVans / totalVans);
+	DieselVans_pct = roundToInt(100.0 * DieselVans / totalVans);
+	ElectricVans_pct = roundToInt(100.0 * ElectricVans / totalVans);
+	HydrogenVans_pct = roundToInt(100.0 * HydrogenVans / totalVans);
 }
 uI_Tabs.pop_tabMobility.get(0).getSliderFossilFuelVans_pct().setValue(DieselVans_pct, false);
 uI_Tabs.pop_tabMobility.get(0).getSliderElectricVans_pct().setValue(ElectricVans_pct, false);
@@ -3955,29 +3959,32 @@ uI_Tabs.pop_tabMobility.get(0).getSliderElectricVans_pct().setValue(ElectricVans
 		
 // DIESEL_VEHICLE:  // Currently only for Company Cars not household Cars / EVs
 int DieselCars = 0;
-int ElectricCars = 0;
+int ElectricCars = uI_Tabs.pop_tabMobility.get(0).v_totalNumberOfGhostVehicle_Cars;
 int HydrogenCars = 0;
 for (GCUtility gc : energyModel.UtilityConnections) {
-	for (J_EAVehicle vehicle : gc.c_vehicleAssets) {
-		if (vehicle instanceof J_EADieselVehicle && vehicle.getEAType() == OL_EnergyAssetType.DIESEL_VEHICLE) {
-			DieselCars += 1;
-		}
-		else if (vehicle instanceof J_EAEV && vehicle.getEAType() == OL_EnergyAssetType.ELECTRIC_VEHICLE) {
-			ElectricCars += 1;
-		}
-		else if (vehicle instanceof J_EAHydrogenVehicle && vehicle.getEAType() == OL_EnergyAssetType.HYDROGEN_VEHICLE) {
-			HydrogenCars += 1;
+	if(gc.v_isActive){
+		for (J_EAVehicle vehicle : gc.c_vehicleAssets) {
+			if (vehicle instanceof J_EADieselVehicle && vehicle.getEAType() == OL_EnergyAssetType.DIESEL_VEHICLE) {
+				DieselCars += 1;
+			}
+			else if (vehicle instanceof J_EAEV && vehicle.getEAType() == OL_EnergyAssetType.ELECTRIC_VEHICLE) {
+				ElectricCars += 1;
+			}
+			else if (vehicle instanceof J_EAHydrogenVehicle && vehicle.getEAType() == OL_EnergyAssetType.HYDROGEN_VEHICLE) {
+				HydrogenCars += 1;
+			}
 		}
 	}
 }
+
 int totalCars = DieselCars + ElectricCars + HydrogenCars;
 int DieselCars_pct = 100;
 int ElectricCars_pct = 0;
 int HydrogenCars_pct = 0;
 if (totalCars != 0) {
-	DieselCars_pct = roundToInt(100 * DieselCars / totalCars);
-	ElectricCars_pct = roundToInt(100 * ElectricCars / totalCars);
-	HydrogenCars_pct = roundToInt(100 * HydrogenCars / totalCars);
+	DieselCars_pct = roundToInt((100.0 * DieselCars) / totalCars);
+	ElectricCars_pct = roundToInt((100.0 * ElectricCars) / totalCars);
+	HydrogenCars_pct = roundToInt((100.0 * HydrogenCars) / totalCars);
 }
 uI_Tabs.pop_tabMobility.get(0).getSliderFossilFuelCars_pct().setValue(DieselCars_pct, false);
 uI_Tabs.pop_tabMobility.get(0).getSliderElectricCars_pct().setValue(ElectricCars_pct, false);
@@ -4067,22 +4074,6 @@ else if (windspeed < 0.8){
 else {
 	v_windspeed = "Zeer hoog";
 }]]></Body>
-				</Function>
-				<Function AccessType="default" StaticFunction="false">
-					<ReturnModificator>VOID</ReturnModificator>
-					<ReturnType><![CDATA[double]]></ReturnType>
-					<Id>1720378447040</Id>
-					<Name><![CDATA[f_setSliderRanges]]></Name>
-					<ExcludeFromBuild>true</ExcludeFromBuild>
-					<X>85</X><Y>-620</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Body><![CDATA[uI_Tabs.tabElectricity.p_minPublicChargerSlider = roundToInt( 100.0 * uI_Tabs.tabElectricity.v_currentNbChargers / uI_Tabs.tabElectricity.p_nbChargersInDatabase);
-uI_Tabs.tabElectricity.sl_EVsWoonwijk.setValue(uI_Tabs.tabElectricity.p_minPublicChargerSlider, false );
-uI_Tabs.tabElectricity.sl_EVsWoonwijk.setRange(uI_Tabs.tabElectricity.sl_EVsWoonwijk.getIntValue(), 100);
-]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
@@ -5305,12 +5296,12 @@ batteryUI.p_amountOfGISObjects = batteryUI.c_GISObjects_Battery.size();
 					<Body><![CDATA[switch(v_clickedObjectType){
 
 case BUILDING:
-	if (c_selectedGridConnections.size() > 1 || !v_clickedBuilding.c_containedGridConnections.get(0).p_owner.b_hasPrivateUI){
+	if (c_selectedGridConnections.size() > 1 || !c_selectedGridConnections.get(0).p_owner.b_hasPrivateUI || !c_selectedGridConnections.get(0).v_isActive){
 		button_goToUI.setVisible(false);
 	}
 	else{
 		// Index number of the connection owner used to change the button '
-		v_connectionOwnerIndexNr = findFirst(energyModel.pop_connectionOwners, p -> p.p_actorID.equals(v_clickedBuilding.c_containedGridConnections.get(0).p_ownerID)).p_connectionOwnerIndexNr;
+		v_connectionOwnerIndexNr = c_selectedGridConnections.get(0).p_owner.p_connectionOwnerIndexNr;
 		button_goToUI.setText("Ga naar het Bedrijfsportaal");
 		button_goToUI.setVisible(true);
 	}
@@ -5631,6 +5622,7 @@ GN.gisRegion.setLineColor(GN.p_uniqueColor.brighter());]]></Body>
 					<PresentationFlag>false</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Body><![CDATA[//Should be overridden in child interface!!!
+f_updateMainInterfaceSliders();
 traceln("Forgot to override project specific slider settings!!");]]></Body>
 				</Function>
 				<Function AccessType="public" StaticFunction="false">
@@ -5645,8 +5637,7 @@ traceln("Forgot to override project specific slider settings!!");]]></Body>
 					<ShowLabel>true</ShowLabel>
 					<Body><![CDATA[//Function used to set the colors, styling, and other parameters/functions for each specific project
 //Should be overridden!!
-
-//traceln("DID NOT OVERRIDE THE PROJECT SPECIFIC STYLING!");]]></Body>
+traceln("DID NOT OVERRIDE THE PROJECT SPECIFIC STYLING!");]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
@@ -5729,6 +5720,19 @@ default:
 }
 
 return p_legendsScope;]]></Body>
+				</Function>
+				<Function AccessType="protected" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1729685968993</Id>
+					<Name><![CDATA[f_projectSpecificOrderedCollectionAdjustments]]></Name>
+					<X>85</X><Y>-620</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[//Function that can be used to make project specific adjustments to the ordered collection
+//SHOULD BE OVERRIDEN IF YOU WANT TO USE THIS]]></Body>
 				</Function>
 			</Functions>
 			<AgentLinks>
@@ -5920,12 +5924,15 @@ return p_legendsScope;]]></Body>
 					<Parameters>
 						<Parameter>
 							<Name><![CDATA[energyModel]]></Name>
-						</Parameter>
-						<Parameter>
-							<Name><![CDATA[p_legendsScope]]></Name>
+							<Value Class="CodeValue">
+								<Code><![CDATA[energyModel]]></Code>
+							</Value>
 						</Parameter>
 						<Parameter>
 							<Name><![CDATA[p_previousTotals_Region]]></Name>
+						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_legendsScope]]></Name>
 						</Parameter>
 					</Parameters>
 					<ReplicationFlag>false</ReplicationFlag>
@@ -10568,6 +10575,29 @@ else {
 					</Font>
 					<Alignment>LEFT</Alignment>
 				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1729789044036</Id>
+					<Name><![CDATA[button_test]]></Name>
+					<X>-260</X><Y>-480</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="100" Height="30">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[traceln("ROVA VANS EV: "+ count(c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VAN && ((GridConnection)p.getParentAgent()).p_ownerID.equals("ROVA Activa Beheer B.V.")));
+traceln("ROVA VANS DIESEL: "+ count(c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VAN && ((GridConnection)p.getParentAgent()).p_ownerID.equals("ROVA Activa Beheer B.V.")));
+]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[button]]></LabelText>
+					</ExtendedProperties>
+				</Control>
 			</Presentation>
 
 				</Level>
@@ -10741,7 +10771,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1713543883957</Id>
 					<Name><![CDATA[v_currentSelectedGCnr]]></Name>
-					<X>-410</X><Y>940</Y>
+					<X>-400</X><Y>420</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10754,39 +10784,9 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 					</Properties>
 				</Variable>
 				<Variable Class="PlainVariable">
-					<Id>1713544066407</Id>
-					<Name><![CDATA[v_heatDemandReduction_pct]]></Name>
-					<X>-410</X><Y>960</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
-						<Type><![CDATA[double]]></Type>        
-						<InitialValue Class="CodeValue">
-							<Code><![CDATA[0]]></Code>
-						</InitialValue>
-					</Properties>
-				</Variable>
-				<Variable Class="PlainVariable">
-					<Id>1713544066409</Id>
-					<Name><![CDATA[v_electricityDemandReduction_pct]]></Name>
-					<X>-410</X><Y>980</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
-						<Type><![CDATA[double]]></Type>        
-						<InitialValue Class="CodeValue">
-							<Code><![CDATA[0]]></Code>
-						</InitialValue>
-					</Properties>
-				</Variable>
-				<Variable Class="PlainVariable">
 					<Id>1713957213075</Id>
 					<Name><![CDATA[v_minPVSlider]]></Name>
-					<X>-1060</X><Y>390</Y>
+					<X>-1060</X><Y>410</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10801,7 +10801,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1713957229701</Id>
 					<Name><![CDATA[v_maxPVSlider]]></Name>
-					<X>-1060</X><Y>410</Y>
+					<X>-1060</X><Y>430</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10816,7 +10816,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1713957233827</Id>
 					<Name><![CDATA[v_defaultPVSlider]]></Name>
-					<X>-1060</X><Y>430</Y>
+					<X>-1060</X><Y>450</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10831,7 +10831,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1713971707023</Id>
 					<Name><![CDATA[v_minBatSlider]]></Name>
-					<X>-1060</X><Y>470</Y>
+					<X>-1060</X><Y>490</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10846,7 +10846,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1713971707027</Id>
 					<Name><![CDATA[v_maxBatSlider]]></Name>
-					<X>-1060</X><Y>490</Y>
+					<X>-1060</X><Y>510</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10861,7 +10861,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1713971707029</Id>
 					<Name><![CDATA[v_defaultBatSlider]]></Name>
-					<X>-1060</X><Y>510</Y>
+					<X>-1060</X><Y>530</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10876,7 +10876,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714139274247</Id>
 					<Name><![CDATA[v_nbEVCars]]></Name>
-					<X>-1050</X><Y>690</Y>
+					<X>-1050</X><Y>710</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10891,7 +10891,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714139294087</Id>
 					<Name><![CDATA[v_nbHydrogenCars]]></Name>
-					<X>-1050</X><Y>730</Y>
+					<X>-1050</X><Y>750</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10906,7 +10906,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714139299844</Id>
 					<Name><![CDATA[v_nbDieselCars]]></Name>
-					<X>-1050</X><Y>710</Y>
+					<X>-1050</X><Y>730</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10921,7 +10921,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714139304156</Id>
 					<Name><![CDATA[v_nbEVVans]]></Name>
-					<X>-1050</X><Y>890</Y>
+					<X>-1050</X><Y>910</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10936,7 +10936,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714139320416</Id>
 					<Name><![CDATA[v_nbEVTrucks]]></Name>
-					<X>-1050</X><Y>1090</Y>
+					<X>-1050</X><Y>1110</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10951,7 +10951,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714139381294</Id>
 					<Name><![CDATA[v_nbDieselVans]]></Name>
-					<X>-1050</X><Y>910</Y>
+					<X>-1050</X><Y>930</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10966,7 +10966,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714139385293</Id>
 					<Name><![CDATA[v_nbDieselTrucks]]></Name>
-					<X>-1050</X><Y>1110</Y>
+					<X>-1050</X><Y>1130</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10981,7 +10981,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714139405729</Id>
 					<Name><![CDATA[v_nbHydrogenVans]]></Name>
-					<X>-1050</X><Y>930</Y>
+					<X>-1050</X><Y>950</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -10996,7 +10996,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714139413565</Id>
 					<Name><![CDATA[v_nbHydrogenTrucks]]></Name>
-					<X>-1050</X><Y>1130</Y>
+					<X>-1050</X><Y>1150</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11011,7 +11011,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714139966993</Id>
 					<Name><![CDATA[v_minEVCarSlider]]></Name>
-					<X>-1050</X><Y>570</Y>
+					<X>-1050</X><Y>590</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11026,7 +11026,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714139997786</Id>
 					<Name><![CDATA[v_minHydrogenCarSlider]]></Name>
-					<X>-1050</X><Y>610</Y>
+					<X>-1050</X><Y>630</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11041,7 +11041,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714140003906</Id>
 					<Name><![CDATA[v_maxEVCarSlider]]></Name>
-					<X>-1050</X><Y>630</Y>
+					<X>-1050</X><Y>650</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11056,7 +11056,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714140007855</Id>
 					<Name><![CDATA[v_minDieselCarSlider]]></Name>
-					<X>-1050</X><Y>590</Y>
+					<X>-1050</X><Y>610</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11071,7 +11071,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714140012482</Id>
 					<Name><![CDATA[v_maxHydrogenCarSlider]]></Name>
-					<X>-1050</X><Y>670</Y>
+					<X>-1050</X><Y>690</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11086,7 +11086,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714140056511</Id>
 					<Name><![CDATA[v_maxDieselCarSlider]]></Name>
-					<X>-1050</X><Y>650</Y>
+					<X>-1050</X><Y>670</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11101,7 +11101,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714141906262</Id>
 					<Name><![CDATA[v_minEVVanSlider]]></Name>
-					<X>-1050</X><Y>770</Y>
+					<X>-1050</X><Y>790</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11116,7 +11116,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714141906264</Id>
 					<Name><![CDATA[v_minHydrogenVanSlider]]></Name>
-					<X>-1050</X><Y>810</Y>
+					<X>-1050</X><Y>830</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11131,7 +11131,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714141906266</Id>
 					<Name><![CDATA[v_maxEVVanSlider]]></Name>
-					<X>-1050</X><Y>830</Y>
+					<X>-1050</X><Y>850</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11146,7 +11146,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714141906268</Id>
 					<Name><![CDATA[v_minDieselVanSlider]]></Name>
-					<X>-1050</X><Y>790</Y>
+					<X>-1050</X><Y>810</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11161,7 +11161,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714141906270</Id>
 					<Name><![CDATA[v_maxHydrogenVanSlider]]></Name>
-					<X>-1050</X><Y>870</Y>
+					<X>-1050</X><Y>890</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11176,7 +11176,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714141906272</Id>
 					<Name><![CDATA[v_maxDieselVanSlider]]></Name>
-					<X>-1050</X><Y>850</Y>
+					<X>-1050</X><Y>870</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11191,7 +11191,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714142030261</Id>
 					<Name><![CDATA[v_minEVTruckSlider]]></Name>
-					<X>-1050</X><Y>970</Y>
+					<X>-1050</X><Y>990</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11206,7 +11206,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714142030263</Id>
 					<Name><![CDATA[v_minHydrogenTruckSlider]]></Name>
-					<X>-1050</X><Y>1010</Y>
+					<X>-1050</X><Y>1030</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11221,7 +11221,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714142030265</Id>
 					<Name><![CDATA[v_maxEVTruckSlider]]></Name>
-					<X>-1050</X><Y>1030</Y>
+					<X>-1050</X><Y>1050</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11236,7 +11236,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714142030267</Id>
 					<Name><![CDATA[v_minDieselTruckSlider]]></Name>
-					<X>-1050</X><Y>990</Y>
+					<X>-1050</X><Y>1010</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11251,7 +11251,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714142030269</Id>
 					<Name><![CDATA[v_maxDieselTruckSlider]]></Name>
-					<X>-1050</X><Y>1050</Y>
+					<X>-1050</X><Y>1070</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11266,7 +11266,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1714142035660</Id>
 					<Name><![CDATA[v_maxHydrogenTruckSlider]]></Name>
-					<X>-1050</X><Y>1070</Y>
+					<X>-1050</X><Y>1090</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11368,7 +11368,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1725614630564</Id>
 					<Name><![CDATA[v_minGCCapacitySlider]]></Name>
-					<X>-1060</X><Y>230</Y>
+					<X>-1060</X><Y>250</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11383,7 +11383,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1725614630566</Id>
 					<Name><![CDATA[v_maxGCCapacitySlider]]></Name>
-					<X>-1060</X><Y>250</Y>
+					<X>-1060</X><Y>270</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11398,7 +11398,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1725614630568</Id>
 					<Name><![CDATA[v_defaultGCCapacitySlider]]></Name>
-					<X>-1060</X><Y>270</Y>
+					<X>-1060</X><Y>290</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11413,7 +11413,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1725625091022</Id>
 					<Name><![CDATA[b_runningMainInterfaceScenarioSettings]]></Name>
-					<X>-380</X><Y>840</Y>
+					<X>-380</X><Y>860</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11428,7 +11428,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1727798399505</Id>
 					<Name><![CDATA[v_minGCCapacitySlider_Feedin]]></Name>
-					<X>-1060</X><Y>310</Y>
+					<X>-1060</X><Y>330</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11443,7 +11443,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1727798399507</Id>
 					<Name><![CDATA[v_maxGCCapacitySlider_Feedin]]></Name>
-					<X>-1060</X><Y>330</Y>
+					<X>-1060</X><Y>350</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11458,7 +11458,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1727798399509</Id>
 					<Name><![CDATA[v_defaultGCCapacitySlider_Feedin]]></Name>
-					<X>-1060</X><Y>350</Y>
+					<X>-1060</X><Y>370</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11473,7 +11473,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1727872520826</Id>
 					<Name><![CDATA[v_physicalConnectionCapacity_kW]]></Name>
-					<X>-1060</X><Y>210</Y>
+					<X>-1060</X><Y>230</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11485,7 +11485,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1727883544535</Id>
 					<Name><![CDATA[v_NFATO_kW_delivery]]></Name>
-					<X>-410</X><Y>1085</Y>
+					<X>-410</X><Y>965</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11497,7 +11497,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1727883574908</Id>
 					<Name><![CDATA[v_NFATO_kW_feedin]]></Name>
-					<X>-410</X><Y>1105</Y>
+					<X>-410</X><Y>985</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11509,13 +11509,28 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="PlainVariable">
 					<Id>1727941212434</Id>
 					<Name><![CDATA[v_NFATO_active]]></Name>
-					<X>-410</X><Y>1065</Y>
+					<X>-410</X><Y>945</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
 						<Type><![CDATA[boolean]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1729686904963</Id>
+					<Name><![CDATA[b_runningMainInterfaceSlider]]></Name>
+					<X>-380</X><Y>880</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[boolean]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[false]]></Code>
+						</InitialValue>
 					</Properties>
 				</Variable>
 				<Variable Class="Parameter">
@@ -11606,7 +11621,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 					<Id>1715181661645</Id>
 					<Name><![CDATA[p_maxAddedVehicles]]></Name>
 					<Description><![CDATA[Amount of vehicles that can additionally be added on the already existing ones]]></Description>
-					<X>-1060</X><Y>1150</Y>
+					<X>-1060</X><Y>1170</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11720,7 +11735,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 				<Variable Class="CollectionVariable">
 					<Id>1727953980115</Id>
 					<Name><![CDATA[c_additionalVehicles]]></Name>
-					<X>-1060</X><Y>1170</Y>
+					<X>-1060</X><Y>1190</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11739,7 +11754,7 @@ import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1713445281785</Id>
 					<Name><![CDATA[f_setScenarioFuture]]></Name>
-					<X>-380</X><Y>550</Y>
+					<X>-380</X><Y>570</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11820,7 +11835,6 @@ sl_electricCarsCompany.setValue(c_scenarioSettings_Current.get(v_currentSelected
 
 //Vans (VOLGORDE BELANGRIJK)
 sl_hydrogenVansCompany.setValue(c_scenarioSettings_Current.get(v_currentSelectedGCnr).getCurrentHydrogenVans() + c_scenarioSettings_Future.get(v_currentSelectedGCnr).getPlannedHydrogenVans(), true);
-
 sl_electricVansCompany.setValue(c_scenarioSettings_Current.get(v_currentSelectedGCnr).getCurrentEVVans() + c_scenarioSettings_Future.get(v_currentSelectedGCnr).getPlannedEVVans(), true);
 //sl_hydrogenVansCompany.setValue(c_scenarioSettings_Current.get(v_currentSelectedGCnr).getCurrentHydrogenVans() + c_scenarioSettings_Future.get(v_currentSelectedGCnr).getPlannedHydrogenVans(), true);
 //sl_dieselVansCompany.setValue(c_scenarioSettings_Future.get(v_currentSelectedGCnr).getPlannedDieselVans(), true);
@@ -11832,6 +11846,8 @@ sl_electricTrucksCompany.setValue(c_scenarioSettings_Current.get(v_currentSelect
 
 //sl_dieselTrucksCompany.setValue(c_scenarioSettings_Future.get(v_currentSelectedGCnr).getPlannedDieselTrucks(), true);
 
+//set active if active in future
+c_ownedGridConnections.get(v_currentSelectedGCnr).f_setActive(c_scenarioSettings_Future.get(v_currentSelectedGCnr).getIsActiveInFuture());
 
 
 //Reset button to future, due to sliders putting it on custom
@@ -11842,7 +11858,7 @@ rb_scenariosPrivateUI.setValue(1, false);]]></Body>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1713447383903</Id>
 					<Name><![CDATA[f_setScenario]]></Name>
-					<X>-400</X><Y>510</Y>
+					<X>-400</X><Y>530</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11861,7 +11877,10 @@ switch (scenario_nr){
 			f_setScenarioCurrent(c_ownedGridConnections.get(v_currentSelectedGCnr));
 		}
 		GCnr_selection.setValue(currentSelectedGCnr_local, true);
-		//traceln("Selected scenario: Current");
+		
+		if(!b_runningMainInterfaceScenarioSettings){
+			traceln("Selected scenario: Current");
+		}
 	break;
 	
 	case 1: // Future
@@ -11870,16 +11889,22 @@ switch (scenario_nr){
 			f_setScenarioFuture(c_ownedGridConnections.get(v_currentSelectedGCnr));
 		}
 		GCnr_selection.setValue(currentSelectedGCnr_local, true);
-		//traceln("Selected scenario: Future");
+		
+		if(!b_runningMainInterfaceScenarioSettings){
+			traceln("Selected scenario: Future");
+		}
 	break;
 	
 	case 2: // Custom
 
 		if(rb_scenariosPrivateUI.getValue() == 2){
-		return;
+			return;
 		}
 		rb_scenariosPrivateUI.setValue(2, false);
-		traceln("Selected scenario: Custom");
+		
+		if(!b_runningMainInterfaceSlider){
+			traceln("Selected scenario: Custom");
+		}
 	break;
 	
 	default:
@@ -11894,7 +11919,7 @@ zero_Interface.b_resultsUpToDate = false;]]></Body>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1713447428490</Id>
 					<Name><![CDATA[f_setScenarioCurrent]]></Name>
-					<X>-380</X><Y>530</Y>
+					<X>-380</X><Y>550</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -11983,6 +12008,9 @@ sl_electricTrucksCompany.setValue(c_scenarioSettings_Current.get(v_currentSelect
 //sl_hydrogenTrucksCompany.setValue(c_scenarioSettings_Current.get(v_currentSelectedGCnr).getCurrentHydrogenTrucks(), true);
 //sl_dieselTrucksCompany.setValue(c_scenarioSettings_Current.get(v_currentSelectedGCnr).getCurrentDieselTrucks(), true);
 
+//set active if active in present
+c_ownedGridConnections.get(v_currentSelectedGCnr).f_setActive(c_scenarioSettings_Current.get(v_currentSelectedGCnr).getIsCurrentlyActive());
+
 //Reset button to current, due to sliders putting it on custom
 rb_scenariosPrivateUI.setValue(0, false);]]></Body>
 				</Function>
@@ -11991,7 +12019,7 @@ rb_scenariosPrivateUI.setValue(0, false);]]></Body>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1713537591106</Id>
 					<Name><![CDATA[f_setHeatingType]]></Name>
-					<X>-400</X><Y>630</Y>
+					<X>-400</X><Y>650</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12004,11 +12032,8 @@ rb_scenariosPrivateUI.setValue(0, false);]]></Body>
 						<Name><![CDATA[selectedHeatingType]]></Name>
 						<Type><![CDATA[OL_GridConnectionHeatingType]]></Type>
 					</Parameter>
-					<Body><![CDATA[//Get current heating type
-OL_GridConnectionHeatingType currentHeatingType = GC.p_heatingType;
-
-//Check if selected is not the same as previous, if not: continue with the setting of new heating type
-if (currentHeatingType == selectedHeatingType){
+					<Body><![CDATA[//Check if selected is not the same as previous, if not: continue with the setting of new heating type
+if (GC.p_heatingType == selectedHeatingType){
 	//traceln("Selected heating type is the same as previous heating type");
 	return;
 }
@@ -12026,6 +12051,8 @@ if (GC.p_secondaryHeatingAsset != null){
 	//main.energyModel.c_ambientAirDependentAssets.remove(secondaryHeatingAsset); // Wanneer is secondary heating type ooit ambient air dependent??
 }
 
+//Set GC heating type as newly selected heating type (NOTE: NEEDS TO HAPPEN HERE, NOT LATER, NOT SOONER)
+GC.p_heatingType = selectedHeatingType;
 
 //Get needed cacacity
 double capacityThermal_kW;
@@ -12128,17 +12155,16 @@ switch (selectedHeatingType){
 	break;
 }
 
-//Set GC heating type as newly selected heating type
-GC.p_heatingType = selectedHeatingType;
-
-zero_Interface.f_updateMainInterfaceSliders();]]></Body>
+if(!b_runningMainInterfaceSlider){
+	zero_Interface.f_updateMainInterfaceSliders();
+}]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1713537591117</Id>
 					<Name><![CDATA[f_setGCCapacity]]></Name>
-					<X>-400</X><Y>650</Y>
+					<X>-400</X><Y>670</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12176,7 +12202,7 @@ GC.f_nfatoSetConnectionCapacity(false);]]></Body>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1713537591121</Id>
 					<Name><![CDATA[f_setBattery]]></Name>
-					<X>-400</X><Y>710</Y>
+					<X>-400</X><Y>730</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12213,25 +12239,9 @@ if(((J_EAStorageElectric)batteryAsset).getCapacityElectric_kW() != 0){
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[double]]></ReturnType>
-					<Id>1713546575512</Id>
-					<Name><![CDATA[f_instantiateSliderVariables]]></Name>
-					<X>-410</X><Y>920</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Body><![CDATA[v_heatDemandReduction_pct = 0;
-v_electricityDemandReduction_pct = 0;
-
-
-]]></Body>
-				</Function>
-				<Function AccessType="default" StaticFunction="false">
-					<ReturnModificator>VOID</ReturnModificator>
-					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1713954180112</Id>
 					<Name><![CDATA[f_setPVSystem]]></Name>
-					<X>-400</X><Y>670</Y>
+					<X>-400</X><Y>690</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12259,7 +12269,9 @@ else{
 	}
 }
 
-zero_Interface.f_updateMainInterfaceSliders();]]></Body>
+if(!b_runningMainInterfaceSlider){
+	zero_Interface.f_updateMainInterfaceSliders();
+}]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
@@ -12267,7 +12279,7 @@ zero_Interface.f_updateMainInterfaceSliders();]]></Body>
 					<Id>1713956765904</Id>
 					<Name><![CDATA[f_setSliderPresets]]></Name>
 					<Description><![CDATA[Set Slider presets (limits, start value, text) for private company sliders]]></Description>
-					<X>-1090</X><Y>150</Y>
+					<X>-1090</X><Y>170</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12310,7 +12322,7 @@ f_setVehicleSliderPresets();
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1714139629738</Id>
 					<Name><![CDATA[f_setPVSliderPresets]]></Name>
-					<X>-1070</X><Y>370</Y>
+					<X>-1070</X><Y>390</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12320,31 +12332,32 @@ sl_rooftopPVCompany.setRange(0, 20000);
 
 //Set range specific for each company
 v_minPVSlider = roundToInt(c_scenarioSettings_Current.get(v_currentSelectedGCnr).getCurrentPV_kW());
-v_maxPVSlider = roundToInt(c_ownedGridConnections.get(v_currentSelectedGCnr).p_roofSurfaceArea_m2*zero_Interface.energyModel.avgc_data.p_avgPVPower_kWpm2);
-v_defaultPVSlider = v_minPVSlider;
-t_rooftopSolarCompany.setText(roundToInt(v_defaultPVSlider) + " kW");]]></Body>
+v_maxPVSlider = roundToInt(0.5 * c_ownedGridConnections.get(v_currentSelectedGCnr).p_roofSurfaceArea_m2*zero_Interface.energyModel.avgc_data.p_avgPVPower_kWpm2);
+v_defaultPVSlider = v_minPVSlider;]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1714139648227</Id>
 					<Name><![CDATA[f_setBatSliderPresets]]></Name>
-					<X>-1070</X><Y>450</Y>
+					<X>-1070</X><Y>470</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
-					<Body><![CDATA[v_minBatSlider = roundToInt(c_scenarioSettings_Current.get(v_currentSelectedGCnr).getCurrentBatteryCapacity_kWh());
+					<Body><![CDATA[//Set back end range (to prevent anylogic errors)
+sl_batteryCompany.setRange(0, 1000);
+
+v_minBatSlider = roundToInt(c_scenarioSettings_Current.get(v_currentSelectedGCnr).getCurrentBatteryCapacity_kWh());
 v_maxBatSlider = Math.max(v_minBatSlider*2, 1000);
-v_defaultBatSlider = v_minBatSlider;
-t_batteryCompany.setText(roundToInt(v_defaultBatSlider) + " kWh");]]></Body>
+v_defaultBatSlider = v_minBatSlider;]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1714139684603</Id>
 					<Name><![CDATA[f_setVehicleSliderPresets]]></Name>
-					<X>-1070</X><Y>530</Y>
+					<X>-1070</X><Y>550</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12363,7 +12376,7 @@ f_setTruckSliderPresets();]]></Body>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1714140108358</Id>
 					<Name><![CDATA[f_setCarSliderPresets]]></Name>
-					<X>-1060</X><Y>550</Y>
+					<X>-1060</X><Y>570</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12397,12 +12410,6 @@ v_nbEVCars = default_nbEVCars;
 v_nbDieselCars = default_nbDieselCars;
 v_nbHydrogenCars = default_nbHydrogenCars;
 
-
-//Set text
-t_numberOfElectricCarsCompany.setText(v_nbEVCars);
-t_numberOfDieselCarsCompany.setText(v_nbDieselCars);
-t_numberOfHydrogenCarsCompany.setText(v_nbHydrogenCars);
-
 //Set slider knobs
 sl_electricCarsCompany.setValue(v_nbEVCars, false);
 sl_dieselCarsCompany.setValue(v_nbDieselCars, false);
@@ -12414,7 +12421,7 @@ sl_hydrogenCarsCompany.setValue(v_nbHydrogenCars, false);
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1714140134819</Id>
 					<Name><![CDATA[f_setVanSliderPresets]]></Name>
-					<X>-1060</X><Y>750</Y>
+					<X>-1060</X><Y>770</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12447,11 +12454,6 @@ v_nbEVVans = default_nbEVVans;
 v_nbDieselVans = default_nbDieselVans;
 v_nbHydrogenVans = default_nbHydrogenVans;
 
-//Set text
-t_numberOfElectricVansCompany.setText(v_nbEVVans);
-t_numberOfDieselVansCompany.setText(v_nbDieselVans);
-t_numberOfHydrogenVansCompany.setText(v_nbHydrogenVans);
-
 //Set slider knob
 sl_electricVansCompany.setValue(v_nbEVVans, false);
 sl_dieselVansCompany.setValue(v_nbDieselVans, false);
@@ -12463,7 +12465,7 @@ sl_hydrogenVansCompany.setValue(v_nbHydrogenVans, false);
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1714140156233</Id>
 					<Name><![CDATA[f_setTruckSliderPresets]]></Name>
-					<X>-1060</X><Y>950</Y>
+					<X>-1060</X><Y>970</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12496,11 +12498,6 @@ v_nbEVTrucks = default_nbEVTrucks;
 v_nbDieselTrucks = default_nbDieselTrucks;
 v_nbHydrogenTrucks = default_nbHydrogenTrucks;
 
-//Set text
-t_numberOfElectricTrucksCompany.setText(v_nbEVTrucks);
-t_numberOfDieselTrucksCompany.setText(v_nbDieselTrucks);
-t_numberOfHydrogenTrucksCompany.setText(v_nbHydrogenTrucks);
-
 //Set slider knob
 sl_electricTrucksCompany.setValue(v_nbEVTrucks, false);
 sl_dieselTrucksCompany.setValue(v_nbDieselTrucks, false);
@@ -12512,7 +12509,7 @@ sl_hydrogenTrucksCompany.setValue(v_nbHydrogenTrucks, false);
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1714410040303</Id>
 					<Name><![CDATA[f_createVehicle]]></Name>
-					<X>-380</X><Y>790</Y>
+					<X>-380</X><Y>810</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12644,7 +12641,7 @@ else{ // (Hydrogen vehicles)
 					<ReturnType><![CDATA[int]]></ReturnType>
 					<Id>1714411599586</Id>
 					<Name><![CDATA[f_setElectricVehicleSliders]]></Name>
-					<X>-400</X><Y>730</Y>
+					<X>-400</X><Y>750</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12732,6 +12729,7 @@ if (setAmountOfVehicles > local_EV_nb){ // Slider has increased the amount of se
 			boolean available = dieselVehicle.getAvailability();
 			dieselVehicle.removeEnergyAsset();
 			c_additionalVehicles.get(GC).remove(dieselVehicle);
+			zero_Interface.c_orderedVehicles.remove(dieselVehicle);
 			
 			//Create new additional EV
 			f_createVehicle(GC, vehicleType, tripTracker, available, true);			
@@ -12750,6 +12748,7 @@ if (setAmountOfVehicles > local_EV_nb){ // Slider has increased the amount of se
 			boolean available = hydrogenVehicle.getAvailability();
 			hydrogenVehicle.removeEnergyAsset();
 			c_additionalVehicles.get(GC).remove(hydrogenVehicle);
+			zero_Interface.c_orderedVehicles.remove(hydrogenVehicle);
 			
 			//Create new additional EV
 			f_createVehicle(GC, vehicleType, tripTracker, available, true);
@@ -12764,8 +12763,8 @@ if (setAmountOfVehicles > local_EV_nb){ // Slider has increased the amount of se
 	while ( setAmountOfVehicles > local_EV_nb && local_DieselV_nb > 0) {
 		
 		// Find a Diesel vehicle
-		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(GC.c_vehicleAssets, p -> p.energyAssetType == vehicleType_diesel);
-		J_ActivityTrackerTrips tripTracker = dieselVehicle.tripTracker;
+		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == vehicleType_diesel && ((GridConnection)p.getParentAgent()) == GC);
+		J_ActivityTrackerTrips tripTracker = dieselVehicle.tripTracker; 
 		
 		// Remove Diesel vehicle		
 		boolean available = dieselVehicle.getAvailability();
@@ -12782,7 +12781,7 @@ if (setAmountOfVehicles > local_EV_nb){ // Slider has increased the amount of se
 	while (setAmountOfVehicles > local_EV_nb && local_HydrogenV_nb > 0){
 	
 		// Find a Hydrogen vehicle
-		J_EAHydrogenVehicle hydrogenVehicle = (J_EAHydrogenVehicle)findFirst(GC.c_vehicleAssets, p -> p.energyAssetType == vehicleType_hydrogen);
+		J_EAHydrogenVehicle hydrogenVehicle = (J_EAHydrogenVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == vehicleType_hydrogen  && ((GridConnection)p.getParentAgent()) == GC);
 		J_ActivityTrackerTrips tripTracker = hydrogenVehicle.tripTracker;
 		
 		// Remove Hydrogen vehicle		
@@ -12817,7 +12816,8 @@ else if(setAmountOfVehicles < local_EV_nb){ // Slider has decreased the amount o
 		
 		// Remove electric vehicle
 		additionalVehicles.remove(ev);
-		c_additionalVehicles.get(c_ownedGridConnections.get(v_currentSelectedGCnr)).remove(ev);
+		c_additionalVehicles.get(GC).remove(ev);
+		zero_Interface.c_orderedVehicles.remove(ev);
 		ev.removeEnergyAsset();
 			
 		//Update variable
@@ -12826,7 +12826,7 @@ else if(setAmountOfVehicles < local_EV_nb){ // Slider has decreased the amount o
 	while ( setAmountOfVehicles < local_EV_nb && local_DieselV_nb < max_amount_diesel_vehicles) {
 
 		//Find a to be removed EV
-		J_EAEV ev = (J_EAEV)findFirst(GC.c_vehicleAssets, p -> p.energyAssetType == vehicleType && !c_additionalVehicles.get(c_ownedGridConnections.get(v_currentSelectedGCnr)).contains(p));
+		J_EAEV ev = (J_EAEV)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == vehicleType && !c_additionalVehicles.get(c_ownedGridConnections.get(v_currentSelectedGCnr)).contains(p)  && ((GridConnection)p.getParentAgent()) == GC);
 		J_ActivityTrackerTrips tripTracker = ev.tripTracker;
 
 		//Remove EV
@@ -12872,14 +12872,16 @@ switch (vehicleType){
 	break;
 }
 
-zero_Interface.f_updateMainInterfaceSliders();]]></Body>
+if(!b_runningMainInterfaceSlider){
+	zero_Interface.f_updateMainInterfaceSliders();
+}]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[int]]></ReturnType>
 					<Id>1714471183392</Id>
 					<Name><![CDATA[f_setDieselVehicleSliders]]></Name>
-					<X>-400</X><Y>770</Y>
+					<X>-400</X><Y>790</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -12971,6 +12973,7 @@ if (setAmountOfVehicles > local_DieselV_nb){ // Slider has increased the amount 
 			boolean available = ev.getAvailability();
 			ev.removeEnergyAsset();
 			c_additionalVehicles.get(GC).remove(ev);
+			zero_Interface.c_orderedVehicles.remove(ev);
 			
 			//Create new additional Diesel vehicle
 			f_createVehicle(GC, vehicleType, tripTracker, available, true);
@@ -12989,6 +12992,7 @@ if (setAmountOfVehicles > local_DieselV_nb){ // Slider has increased the amount 
 			boolean available = hydrogenVehicle.getAvailability();
 			hydrogenVehicle.removeEnergyAsset();
 			c_additionalVehicles.get(GC).remove(hydrogenVehicle);
+			zero_Interface.c_orderedVehicles.remove(hydrogenVehicle);
 			
 			//Create new additional Diesel vehicle
 			f_createVehicle(GC, vehicleType, tripTracker, available, true);
@@ -13002,7 +13006,7 @@ if (setAmountOfVehicles > local_DieselV_nb){ // Slider has increased the amount 
 	while ( setAmountOfVehicles > local_DieselV_nb && local_EV_nb > min_amount_EV) {
 
 		// Find an EV
-		J_EAEV ev = (J_EAEV)findFirst(GC.c_vehicleAssets, p -> p.energyAssetType == vehicleType_electric);
+		J_EAEV ev = (J_EAEV)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == vehicleType_electric  && ((GridConnection)p.getParentAgent()) == GC);
 		J_ActivityTrackerTrips tripTracker = ev.tripTracker;
 		
 		//Remove one EV
@@ -13020,7 +13024,7 @@ if (setAmountOfVehicles > local_DieselV_nb){ // Slider has increased the amount 
 	while (setAmountOfVehicles > local_DieselV_nb && local_HydrogenV_nb > 0){
 	
 		// Find a Hydrogen vehicle
-		J_EAHydrogenVehicle hydrogenVehicle = (J_EAHydrogenVehicle)findFirst(GC.c_vehicleAssets, p -> p.energyAssetType == vehicleType_hydrogen);// && !c_additionalVehicles.get(c_ownedGridConnections.get(v_currentSelectedGCnr)).contains(p));
+		J_EAHydrogenVehicle hydrogenVehicle = (J_EAHydrogenVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == vehicleType_hydrogen  && ((GridConnection)p.getParentAgent()) == GC);
 		J_ActivityTrackerTrips tripTracker = hydrogenVehicle.tripTracker;
 		
 		// Remove hydrogen vehicle			
@@ -13052,8 +13056,9 @@ else if(setAmountOfVehicles < local_DieselV_nb){ // Slider has decreased the amo
 	
 	// Remove diesel vehicle
 	additionalVehicles.remove(dieselVehicle);
-	c_additionalVehicles.get(c_ownedGridConnections.get(v_currentSelectedGCnr)).remove(dieselVehicle);
+	c_additionalVehicles.get(GC).remove(dieselVehicle);
 	dieselVehicle.removeEnergyAsset();
+	zero_Interface.c_orderedVehicles.remove(dieselVehicle);
 	
 	//Update variable
 	local_DieselV_nb--;
@@ -13061,7 +13066,7 @@ else if(setAmountOfVehicles < local_DieselV_nb){ // Slider has decreased the amo
 	while ( setAmountOfVehicles < local_DieselV_nb && local_EV_nb < max_amount_EV) {
 	
 	// Find a to be removed Diesel vehicle
-		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(GC.c_vehicleAssets, p -> p.energyAssetType == vehicleType && !c_additionalVehicles.get(c_ownedGridConnections.get(v_currentSelectedGCnr)).contains(p));
+		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == vehicleType && !c_additionalVehicles.get(c_ownedGridConnections.get(v_currentSelectedGCnr)).contains(p)  && ((GridConnection)p.getParentAgent()) == GC);
 		J_ActivityTrackerTrips tripTracker = dieselVehicle.tripTracker;
 		
 		// Remove diesel vehicle		
@@ -13102,14 +13107,16 @@ switch (vehicleType){
 	break;
 }
 
-zero_Interface.f_updateMainInterfaceSliders();]]></Body>
+if(!b_runningMainInterfaceSlider){
+	zero_Interface.f_updateMainInterfaceSliders();
+}]]></Body>
 				</Function>
 				<Function AccessType="public" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[int]]></ReturnType>
 					<Id>1714474430338</Id>
 					<Name><![CDATA[f_setHydrogenVehicleSliders]]></Name>
-					<X>-400</X><Y>750</Y>
+					<X>-400</X><Y>770</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -13201,6 +13208,7 @@ if (setAmountOfVehicles > local_HydrogenV_nb){ // Slider has increased the amoun
 			boolean available = dieselVehicle.getAvailability();
 			dieselVehicle.removeEnergyAsset();
 			c_additionalVehicles.get(GC).remove(dieselVehicle);
+			zero_Interface.c_orderedVehicles.remove(dieselVehicle);
 			
 			//Create new additional Hydrogen vehicle
 			f_createVehicle(GC, vehicleType, tripTracker, available, true);			
@@ -13219,6 +13227,7 @@ if (setAmountOfVehicles > local_HydrogenV_nb){ // Slider has increased the amoun
 			boolean available = ev.getAvailability();
 			ev.removeEnergyAsset();
 			c_additionalVehicles.get(GC).remove(ev);
+			zero_Interface.c_orderedVehicles.remove(ev);
 			
 			//Create new additional Hydrogen vehicle
 			f_createVehicle(GC, vehicleType, tripTracker, available, true);
@@ -13232,7 +13241,7 @@ if (setAmountOfVehicles > local_HydrogenV_nb){ // Slider has increased the amoun
 	while ( setAmountOfVehicles > local_HydrogenV_nb && local_DieselV_nb > 0) {
 
 		// Find a to be removed Diesel vehicle
-		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(GC.c_vehicleAssets, p -> p.energyAssetType == vehicleType_diesel);
+		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == vehicleType_diesel  && ((GridConnection)p.getParentAgent()) == GC);
 		J_ActivityTrackerTrips tripTracker = dieselVehicle.tripTracker;
 
 		//Remove diesel vehicle
@@ -13251,7 +13260,7 @@ if (setAmountOfVehicles > local_HydrogenV_nb){ // Slider has increased the amoun
 	while (setAmountOfVehicles > local_HydrogenV_nb && local_EV_nb > min_amount_EV){
 		
 		// Find a to be removed EV
-		J_EAEV ev = (J_EAEV)findFirst(GC.c_vehicleAssets, p -> p.energyAssetType == vehicleType_electric);
+		J_EAEV ev = (J_EAEV)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == vehicleType_electric  && ((GridConnection)p.getParentAgent()) == GC);
 		J_ActivityTrackerTrips tripTracker = ev.tripTracker;
 		
 		// Remove EV
@@ -13286,14 +13295,15 @@ else if(setAmountOfVehicles < local_HydrogenV_nb){ // Slider has decreased the a
 	additionalVehicles.remove(hydrogenVehicle);
 	c_additionalVehicles.get(c_ownedGridConnections.get(v_currentSelectedGCnr)).remove(hydrogenVehicle);
 	hydrogenVehicle.removeEnergyAsset();
-		
+	zero_Interface.c_orderedVehicles.remove(hydrogenVehicle);
+	
 	//Update variable
 	local_HydrogenV_nb--;
 	}
 	while ( setAmountOfVehicles < local_HydrogenV_nb && local_EV_nb < max_amount_EV) {
 	
 		// Find a to be removed Hydrogen vehicle
-		J_EAHydrogenVehicle hydrogenVehicle = (J_EAHydrogenVehicle)findFirst(GC.c_vehicleAssets, p -> p.energyAssetType == vehicleType && !c_additionalVehicles.get(c_ownedGridConnections.get(v_currentSelectedGCnr)).contains(p));
+		J_EAHydrogenVehicle hydrogenVehicle = (J_EAHydrogenVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == vehicleType && !c_additionalVehicles.get(c_ownedGridConnections.get(v_currentSelectedGCnr)).contains(p)  && ((GridConnection)p.getParentAgent()) == GC);
 		J_ActivityTrackerTrips tripTracker = hydrogenVehicle.tripTracker;
 		
 		// Remove hydrogen vehicle			
@@ -13338,7 +13348,9 @@ switch (vehicleType){
 	break;
 }
 
-zero_Interface.f_updateMainInterfaceSliders();]]></Body>
+if(!b_runningMainInterfaceSlider){
+	zero_Interface.f_updateMainInterfaceSliders();
+}]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
@@ -13385,8 +13397,7 @@ uI_Results.f_styleAllCharts(v_chartBackgroundColor, v_companyUILineColor, v_char
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
-					<Body><![CDATA[//traceln(p_companyName);
-//Set GC combobox 
+					<Body><![CDATA[//Set GC combobox 
 f_setComboBoxGC();
 
 //Initialize graph locations and visibility
@@ -13398,7 +13409,11 @@ f_setSliderPresets();
 //Scale companyName to the box size
 f_setNameTextSize();
 
-]]></Body>
+
+//Enable/disable all sliders (based on paused)
+if(!c_ownedGridConnections.get(v_currentSelectedGCnr).v_isActive){
+	f_enableAllSliders(false);
+}]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
@@ -13420,7 +13435,7 @@ uI_Results.v_trafo = zero_Interface.uI_Results.v_trafo;]]></Body>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1715713362876</Id>
 					<Name><![CDATA[f_setHeatingRB]]></Name>
-					<X>-1070</X><Y>170</Y>
+					<X>-1070</X><Y>190</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -13459,13 +13474,20 @@ switch (c_scenarioSettings_Current.get(v_currentSelectedGCnr).getCurrentHeatingT
 if (rbHeating_acces.equals("disabled") || rbHeating_acces.equals("invisible")){
 	rb_heatingTypePrivateUI.setEnabled(false);
 	
+	if(c_ownedGridConnections.get(v_currentSelectedGCnr).v_hasQuarterHourlyValues){
+		sl_heatDemandCompanyReduction.setEnabled(false);
+	}
+	
 	if (rbHeating_acces.equals("invisible")){
 		rb_heatingTypePrivateUI.setVisible(false);
+		gr_heatDemandReductionSlider.setVisible(false);
 	}
 }
 else{ // if(rbHeating_acces.equals("enabled"){
 	rb_heatingTypePrivateUI.setEnabled(true);
 	rb_heatingTypePrivateUI.setVisible(true);
+	sl_heatDemandCompanyReduction.setEnabled(true);
+	sl_heatDemandCompanyReduction.setVisible(true);
 }
 
 rb_heatingTypePrivateUI.setValue(nr_currentHeatingType, false);]]></Body>
@@ -13475,7 +13497,7 @@ rb_heatingTypePrivateUI.setValue(nr_currentHeatingType, false);]]></Body>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1715952034311</Id>
 					<Name><![CDATA[f_addPVAsset]]></Name>
-					<X>-380</X><Y>690</Y>
+					<X>-380</X><Y>710</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -13511,7 +13533,7 @@ J_EAProduction production_asset = new J_EAProduction(parentGC, asset_type, asset
 					<Id>1717576974529</Id>
 					<Name><![CDATA[f_setSelectedGC]]></Name>
 					<Description><![CDATA[Function that sets the sliders to match the currently present settings of the energy assets owned by the selected GC. Used when a connection owner has multiple grid connections, and wants to set the sliders of a different GC. ]]></Description>
-					<X>-400</X><Y>420</Y>
+					<X>-400</X><Y>440</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -13523,7 +13545,7 @@ v_adressGC = c_ownedGridConnections.get(v_currentSelectedGCnr).p_address.getAddr
 f_setSelectedGCSliders();
 
 //Set the new graphs/building selection
-if(!b_runningMainInterfaceScenarioSettings){
+if(!b_runningMainInterfaceScenarioSettings && !b_runningMainInterfaceSlider && c_ownedGridConnections.get(v_currentSelectedGCnr).v_isActive){
 	f_setSelectedGCGraphs();
 }]]></Body>
 				</Function>
@@ -13532,17 +13554,19 @@ if(!b_runningMainInterfaceScenarioSettings){
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1725439625846</Id>
 					<Name><![CDATA[f_setSelectedGCSliders]]></Name>
-					<X>-370</X><Y>440</Y>
+					<X>-370</X><Y>460</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Body><![CDATA[//Reset GC capacities to without NFATO values
 c_ownedGridConnections.get(v_currentSelectedGCnr).f_nfatoSetConnectionCapacity(true);
-
+	
 //Initialize slider presets to selected GC (min, max, etc.)
 f_setSliderPresets();
 
+//If GC not active in current situation, disable scenario rb
+rb_scenariosPrivateUI.setEnabled(c_scenarioSettings_Current.get(v_currentSelectedGCnr).getIsCurrentlyActive());
 
 //Find the current heating type
 int nr_currentHeatingType = 0;
@@ -13661,32 +13685,24 @@ rb_heatingTypePrivateUI.setValue(nr_currentHeatingType, false);
 
 //Heat savings
 sl_heatDemandCompanyReduction.setValue(currentHeatSavings, false);
-t_heatDemandReductionCompanies.setText(currentHeatSavings + "%");
-v_heatDemandReduction_pct = currentHeatSavings;
 
 //Electricity savings
 sl_electricityDemandCompanyReduction.setValue(currentElectricitySavings, false);
-t_electricityDemandReductionCompany.setText(currentElectricitySavings + "%");
-v_electricityDemandReduction_pct = currentElectricitySavings;
 
 //Contract connection capacity (delivery)
 sl_GCCapacityCompany.setValue(GCContractCapacityCurrent_Delivery, false);
-t_GCCapacityCompany.setText(GCContractCapacityCurrent_Delivery + " kW");
 v_defaultGCCapacitySlider = GCContractCapacityCurrent_Delivery;
 
 //Contract connection capacity (feedin)
 sl_GCCapacityCompany_Feedin.setValue(GCContractCapacityCurrent_Feedin, false);
-t_GCCapacityCompany_Feedin.setText(GCContractCapacityCurrent_Feedin + " kW");
 v_defaultGCCapacitySlider_Feedin = GCContractCapacityCurrent_Feedin;
 
 //Battery capacity
 sl_batteryCompany.setValue(BatteryCapacityCurrent, false);
-t_batteryCompany.setText(BatteryCapacityCurrent + " kWh");
 v_defaultBatSlider = BatteryCapacityCurrent;
 
 //Solar panel power
 sl_rooftopPVCompany.setValue(PVCapacityCurrent, false);
-t_rooftopSolarCompany.setText(PVCapacityCurrent + " kW");
 v_defaultPVSlider = PVCapacityCurrent;
 
 //Curtailment setting
@@ -13695,16 +13711,11 @@ cb_curtailmentCompany.setSelected(currentCurtailmentSetting, false);
 
 //Mobility savings
 sl_mobilityDemandCompanyReduction.setValue(currentTransportSavings, false);
-t_mobilityDemandReductionCompany.setText(currentTransportSavings + "%");
 
 //Cars 
 sl_electricCarsCompany.setValue(nbEcarsCurrent, false);
 sl_hydrogenCarsCompany.setValue(nbHydrogencarsCurrent, false);
 sl_dieselCarsCompany.setValue(nbDieselcarsCurrent, false);
-
-t_numberOfElectricCarsCompany.setText(nbEcarsCurrent);
-t_numberOfHydrogenCarsCompany.setText(nbHydrogencarsCurrent);
-t_numberOfDieselCarsCompany.setText(nbDieselcarsCurrent);
 
 v_nbEVCars = nbEcarsCurrent;
 v_nbHydrogenCars = nbHydrogencarsCurrent;
@@ -13716,10 +13727,6 @@ sl_electricVansCompany.setValue(nbEvansCurrent, false);
 sl_hydrogenVansCompany.setValue(nbHydrogenvansCurrent, false);
 sl_dieselVansCompany.setValue(nbDieselvansCurrent, false);
 
-t_numberOfElectricVansCompany.setText(nbEvansCurrent);
-t_numberOfHydrogenVansCompany.setText(nbHydrogenvansCurrent);
-t_numberOfDieselVansCompany.setText(nbDieselvansCurrent);
-
 v_nbEVVans = nbEvansCurrent;
 v_nbHydrogenVans = nbHydrogenvansCurrent;
 v_nbDieselVans = nbDieselvansCurrent;
@@ -13729,10 +13736,6 @@ v_nbDieselVans = nbDieselvansCurrent;
 sl_electricTrucksCompany.setValue(nbEtrucksCurrent, false);
 sl_hydrogenTrucksCompany.setValue(nbHydrogentrucksCurrent, false);
 sl_dieselTrucksCompany.setValue(nbDieseltrucksCurrent, false);
-
-t_numberOfElectricTrucksCompany.setText(nbEtrucksCurrent);
-t_numberOfHydrogenTrucksCompany.setText(nbHydrogentrucksCurrent);
-t_numberOfDieselTrucksCompany.setText(nbDieseltrucksCurrent);
 
 v_nbEVTrucks = nbEtrucksCurrent;
 v_nbHydrogenTrucks = nbHydrogentrucksCurrent;
@@ -13748,7 +13751,7 @@ c_ownedGridConnections.get(v_currentSelectedGCnr).f_nfatoSetConnectionCapacity(f
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1725439635605</Id>
 					<Name><![CDATA[f_setSelectedGCGraphs]]></Name>
-					<X>-370</X><Y>460</Y>
+					<X>-370</X><Y>480</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -13766,14 +13769,14 @@ uI_Results.f_setAllCharts();]]></Body>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1725607045331</Id>
 					<Name><![CDATA[f_setSimulateYearScreen]]></Name>
-					<X>-400</X><Y>820</Y>
+					<X>-400</X><Y>840</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Body><![CDATA[gr_simulateYearScreen.setVisible(true);
 
-if(!b_runningMainInterfaceScenarioSettings){
+if(!b_runningMainInterfaceScenarioSettings && !b_runningMainInterfaceSlider){
 	//Set life profiles as visible graph
 	uI_Results.chartProfielen.getPeriodRadioButton().setValue(0, true);
 }
@@ -13786,7 +13789,7 @@ zero_Interface.f_resetSettings();]]></Body>
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1725614403909</Id>
 					<Name><![CDATA[f_setGCCapacitySliderPresets]]></Name>
-					<X>-1070</X><Y>190</Y>
+					<X>-1070</X><Y>210</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -13819,8 +13822,6 @@ else{
 
 v_defaultGCCapacitySlider = roundToInt(defaultGCCapacitySlider);
 
-t_GCCapacityCompany.setText(roundToInt(v_defaultGCCapacitySlider) + " kW");
-
 //Set slider knob
 sl_GCCapacityCompany.setValue(v_defaultGCCapacitySlider, false);]]></Body>
 				</Function>
@@ -13852,7 +13853,7 @@ if(nameLength > 24){
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1727798399503</Id>
 					<Name><![CDATA[f_setGCCapacitySliderPresets_Feedin]]></Name>
-					<X>-1070</X><Y>290</Y>
+					<X>-1070</X><Y>310</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -13878,8 +13879,6 @@ else{
 
 v_defaultGCCapacitySlider_Feedin = roundToInt(defaultGCCapacitySlider_Feedin);
 
-t_GCCapacityCompany_Feedin.setText(roundToInt(v_defaultGCCapacitySlider_Feedin) + " kW");
-
 //Set slider knob
 sl_GCCapacityCompany_Feedin.setValue(v_defaultGCCapacitySlider_Feedin, false);]]></Body>
 				</Function>
@@ -13888,7 +13887,7 @@ sl_GCCapacityCompany_Feedin.setValue(v_defaultGCCapacitySlider_Feedin, false);]]
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1727884380899</Id>
 					<Name><![CDATA[f_getNFATOValues]]></Name>
-					<X>-410</X><Y>1045</Y>
+					<X>-410</X><Y>925</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -13917,6 +13916,47 @@ else{
 	t_GCCapacityCompany_Feedin_nfato.setColor(black);
 }
 ]]></Body>
+				</Function>
+				<Function AccessType="public" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1729515671654</Id>
+					<Name><![CDATA[f_enableAllSliders]]></Name>
+					<X>-1070</X><Y>120</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[enable]]></Name>
+						<Type><![CDATA[boolean]]></Type>
+					</Parameter>
+					<Body><![CDATA[sl_heatDemandCompanyReduction.setEnabled(enable);
+rb_heatingTypePrivateUI.setEnabled(enable);
+
+sl_electricityDemandCompanyReduction.setEnabled(enable);
+sl_GCCapacityCompany.setEnabled(enable);
+sl_GCCapacityCompany_Feedin.setEnabled(enable);
+sl_batteryCompany.setEnabled(enable);
+sl_rooftopPVCompany.setEnabled(enable);
+cb_curtailmentCompany.setEnabled(enable);
+
+sl_mobilityDemandCompanyReduction.setEnabled(enable);
+
+sl_electricCarsCompany.setEnabled(enable);
+sl_hydrogenCarsCompany.setEnabled(enable);
+sl_dieselCarsCompany.setEnabled(enable);
+
+sl_electricVansCompany.setEnabled(enable);
+sl_hydrogenVansCompany.setEnabled(enable);
+sl_dieselVansCompany.setEnabled(enable);
+
+sl_electricTrucksCompany.setEnabled(enable);
+sl_hydrogenTrucksCompany.setEnabled(enable);
+sl_dieselTrucksCompany.setEnabled(enable);
+
+//Set heating rb to correct setting (no matter what input of this function is)
+f_setHeatingRB();]]></Body>
 				</Function>
 			</Functions>
 			<AgentLinks>
@@ -13981,12 +14021,15 @@ else{
 					<Parameters>
 						<Parameter>
 							<Name><![CDATA[energyModel]]></Name>
-						</Parameter>
-						<Parameter>
-							<Name><![CDATA[p_legendsScope]]></Name>
+							<Value Class="CodeValue">
+								<Code><![CDATA[zero_Interface.energyModel]]></Code>
+							</Value>
 						</Parameter>
 						<Parameter>
 							<Name><![CDATA[p_previousTotals_Region]]></Name>
+						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_legendsScope]]></Name>
 						</Parameter>
 					</Parameters>
 					<ReplicationFlag>false</ReplicationFlag>
@@ -14302,7 +14345,7 @@ zero_Interface.f_resetSettings();]]></ActionCode>
 				<Text>
 					<Id>1713537625797</Id>
 					<Name><![CDATA[txt_scenarioSettings]]></Name>
-					<X>-410</X><Y>480</Y>
+					<X>-410</X><Y>500</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -14321,30 +14364,9 @@ zero_Interface.f_resetSettings();]]></ActionCode>
 					<Alignment>LEFT</Alignment>
 				</Text>
 				<Text>
-					<Id>1713544087067</Id>
-					<Name><![CDATA[txt_sliderVariables]]></Name>
-					<X>-420</X><Y>890</Y>
-					<Label><X>0</X><Y>-10</Y></Label>
-					<PublicFlag>true</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<DrawMode>SHAPE_DRAW_2D</DrawMode>
-					<EmbeddedIcon>false</EmbeddedIcon>
-					<Z>0</Z>
-					<Rotation>0.0</Rotation>
-					<Color>-16777216</Color>
-					<Text><![CDATA[Slider variables]]></Text>
-					<Font>
-						<Name>SansSerif</Name>
-						<Size>12</Size>
-						<Style>0</Style>
-					</Font>
-					<Alignment>LEFT</Alignment>
-				</Text>
-				<Text>
 					<Id>1713957149840</Id>
 					<Name><![CDATA[txt_sliderPresetsAndLimits]]></Name>
-					<X>-1100</X><Y>120</Y>
+					<X>-1100</X><Y>140</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -14365,7 +14387,7 @@ zero_Interface.f_resetSettings();]]></ActionCode>
 				<Text>
 					<Id>1713957196998</Id>
 					<Name><![CDATA[txt_sliderFunctions]]></Name>
-					<X>-410</X><Y>600</Y>
+					<X>-410</X><Y>620</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -14516,6 +14538,7 @@ zero_Interface.f_resetSettings();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0 kW]]></Text>
+					<TextCode><![CDATA[sl_GCCapacityCompany.getIntValue() + " kW"]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -14537,7 +14560,6 @@ zero_Interface.f_resetSettings();]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[f_setGCCapacity(c_ownedGridConnections.get(v_currentSelectedGCnr), sl_GCCapacityCompany.getValue(), "DELIVERY");
-t_GCCapacityCompany.setText(roundToInt(sl_GCCapacityCompany.getValue()) + " kW");
 
 //Set scenario to custom
 f_setScenario(2);
@@ -14577,7 +14599,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 				</Text>
 				<Group>
 					<Id>1713446065831</Id>
-					<Name><![CDATA[gr_heatDemandSliders]]></Name>
+					<Name><![CDATA[gr_heatDemandReductionSlider]]></Name>
 					<X>-120</X><Y>-100</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>true</PublicFlag>
@@ -14618,10 +14640,6 @@ for (J_EA j_ea : c_ownedGridConnections.get(v_currentSelectedGCnr).c_energyAsset
 		}
 	}
 }
-
-
-v_heatDemandReduction_pct = newHeatDemandReduction_pct;
-t_heatDemandReductionCompanies.setText(roundToInt(newHeatDemandReduction_pct) + "%");
 
 //Set scenario to custom
 f_setScenario(2);
@@ -14673,6 +14691,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0%]]></Text>
+					<TextCode><![CDATA[sl_heatDemandCompanyReduction.getIntValue() + "%"]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -14739,6 +14758,8 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0%]]></Text>
+					<TextCode><![CDATA[sl_electricityDemandCompanyReduction.getIntValue() + "%"
+]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -14775,9 +14796,6 @@ for (J_EA j_ea : c_ownedGridConnections.get(v_currentSelectedGCnr).c_energyAsset
 		}
 	}
 }
-
-v_electricityDemandReduction_pct = newElectricityDemandReduction_pct;
-t_electricityDemandReductionCompany.setText(roundToInt(newElectricityDemandReduction_pct) + "%");
 
 //Set scenario to custom
 f_setScenario(2);
@@ -14846,15 +14864,9 @@ f_setSimulateYearScreen();
 						<ActionCode><![CDATA[//Slider function
 f_setElectricVehicleSliders(c_ownedGridConnections.get(v_currentSelectedGCnr), OL_EnergyAssetType.ELECTRIC_VAN, (int)sl_electricVansCompany.getValue());
 
-//Update slider number
-t_numberOfElectricVansCompany.setText((int)sl_electricVansCompany.getValue());
-
 //Update the other two sliders aswell
 sl_hydrogenVansCompany.setValue(v_nbHydrogenVans, false);
 sl_dieselVansCompany.setValue(v_nbDieselVans, false);
-
-t_numberOfHydrogenVansCompany.setText(v_nbHydrogenVans);
-t_numberOfDieselVansCompany.setText(v_nbDieselVans);
 
 //Set scenario to custom
 f_setScenario(2);
@@ -14907,6 +14919,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0]]></Text>
+					<TextCode><![CDATA[sl_electricVansCompany.getIntValue()]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -14930,15 +14943,9 @@ f_setSimulateYearScreen();]]></ActionCode>
 						<ActionCode><![CDATA[//Slider function
 f_setHydrogenVehicleSliders(c_ownedGridConnections.get(v_currentSelectedGCnr), OL_EnergyAssetType.HYDROGEN_VAN, (int)sl_hydrogenVansCompany.getValue());
 
-//Update slider number
-t_numberOfHydrogenVansCompany.setText((int)sl_hydrogenVansCompany.getValue());
-
 //Update the other two sliders aswell
 sl_electricVansCompany.setValue(v_nbEVVans, false);
 sl_dieselVansCompany.setValue(v_nbDieselVans, false);
-
-t_numberOfElectricVansCompany.setText(v_nbEVVans);
-t_numberOfDieselVansCompany.setText(v_nbDieselVans);
 
 //Set scenario to custom
 f_setScenario(2);
@@ -14991,6 +14998,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0]]></Text>
+					<TextCode><![CDATA[sl_hydrogenVansCompany.getIntValue()]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -15014,15 +15022,9 @@ f_setSimulateYearScreen();]]></ActionCode>
 						<ActionCode><![CDATA[//Slider function
 f_setDieselVehicleSliders(c_ownedGridConnections.get(v_currentSelectedGCnr), OL_EnergyAssetType.DIESEL_VAN, (int)sl_dieselVansCompany.getValue());
 
-//Update slider number
-t_numberOfDieselVansCompany.setText((int)sl_dieselVansCompany.getValue());
-
 //Update the other two sliders aswell
 sl_electricVansCompany.setValue(v_nbEVVans, false);
 sl_hydrogenVansCompany.setValue(v_nbHydrogenVans, false);
-
-t_numberOfElectricVansCompany.setText(v_nbEVVans);
-t_numberOfHydrogenVansCompany.setText(v_nbHydrogenVans);
 
 //Set scenario to custom
 f_setScenario(2);
@@ -15075,6 +15077,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0]]></Text>
+					<TextCode><![CDATA[sl_dieselVansCompany.getIntValue()]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -15117,6 +15120,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0]]></Text>
+					<TextCode><![CDATA[sl_dieselTrucksCompany.getIntValue()]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -15138,6 +15142,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0]]></Text>
+					<TextCode><![CDATA[sl_hydrogenTrucksCompany.getIntValue()]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -15245,15 +15250,9 @@ f_setSimulateYearScreen();]]></ActionCode>
 						<ActionCode><![CDATA[//Slider function
 f_setHydrogenVehicleSliders(c_ownedGridConnections.get(v_currentSelectedGCnr), OL_EnergyAssetType.HYDROGEN_TRUCK, (int)sl_hydrogenTrucksCompany.getValue());
 
-//Update slider number
-t_numberOfHydrogenTrucksCompany.setText((int)sl_hydrogenTrucksCompany.getValue());
-
 //Update the other two sliders aswell
 sl_electricTrucksCompany.setValue(v_nbEVTrucks, false);
 sl_dieselTrucksCompany.setValue(v_nbDieselTrucks, false);
-
-t_numberOfElectricTrucksCompany.setText(v_nbEVTrucks);
-t_numberOfDieselTrucksCompany.setText(v_nbDieselTrucks);
 
 //Set scenario to custom
 f_setScenario(2);
@@ -15285,6 +15284,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0]]></Text>
+					<TextCode><![CDATA[sl_electricTrucksCompany.getIntValue()]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -15308,15 +15308,9 @@ f_setSimulateYearScreen();]]></ActionCode>
 						<ActionCode><![CDATA[//Slider function
 f_setElectricVehicleSliders(c_ownedGridConnections.get(v_currentSelectedGCnr), OL_EnergyAssetType.ELECTRIC_TRUCK, (int)sl_electricTrucksCompany.getValue());
 
-//Update slider number
-t_numberOfElectricTrucksCompany.setText((int)sl_electricTrucksCompany.getValue());
-
 //Update the other two sliders aswell
 sl_hydrogenTrucksCompany.setValue(v_nbHydrogenTrucks, false);
 sl_dieselTrucksCompany.setValue(v_nbDieselTrucks, false);
-
-t_numberOfHydrogenTrucksCompany.setText(v_nbHydrogenTrucks);
-t_numberOfDieselTrucksCompany.setText(v_nbDieselTrucks);
 
 //Set scenario to custom
 f_setScenario(2);
@@ -15350,15 +15344,9 @@ f_setSimulateYearScreen();]]></ActionCode>
 						<ActionCode><![CDATA[//Slider function
 f_setDieselVehicleSliders(c_ownedGridConnections.get(v_currentSelectedGCnr), OL_EnergyAssetType.DIESEL_TRUCK, (int)sl_dieselTrucksCompany.getValue());
 
-//Update slider number
-t_numberOfDieselTrucksCompany.setText((int)sl_dieselTrucksCompany.getValue());
-
 //Update the other two sliders aswell
 sl_electricTrucksCompany.setValue(v_nbEVTrucks, false);
 sl_hydrogenTrucksCompany.setValue(v_nbHydrogenTrucks, false);
-
-t_numberOfElectricTrucksCompany.setText(v_nbEVTrucks);
-t_numberOfHydrogenTrucksCompany.setText(v_nbHydrogenTrucks);
 
 //Set scenario to custom
 f_setScenario(2);
@@ -15392,15 +15380,9 @@ f_setSimulateYearScreen();]]></ActionCode>
 						<ActionCode><![CDATA[//Slider function
 f_setElectricVehicleSliders(c_ownedGridConnections.get(v_currentSelectedGCnr), OL_EnergyAssetType.ELECTRIC_VEHICLE, (int)sl_electricCarsCompany.getValue());
 
-//Update slider number
-t_numberOfElectricCarsCompany.setText((int)sl_electricCarsCompany.getValue());
-
 //Update the other two sliders aswell
 sl_hydrogenCarsCompany.setValue(v_nbHydrogenCars, false);
 sl_dieselCarsCompany.setValue(v_nbDieselCars, false);
-
-t_numberOfHydrogenCarsCompany.setText(v_nbHydrogenCars);
-t_numberOfDieselCarsCompany.setText(v_nbDieselCars);
 
 //Set scenario to custom
 f_setScenario(2);
@@ -15453,6 +15435,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0]]></Text>
+					<TextCode><![CDATA[sl_electricCarsCompany.getIntValue()]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -15495,7 +15478,6 @@ f_setSimulateYearScreen();]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[c_ownedGridConnections.get(v_currentSelectedGCnr).c_tripTrackers.forEach(tt -> tt.distanceScaling_fr = 1-sl_mobilityDemandCompanyReduction.getValue()/100);
-t_mobilityDemandReductionCompany.setText(roundToInt(sl_mobilityDemandCompanyReduction.getValue()) + "%");
 
 //Set scenario to custom
 f_setScenario(2);
@@ -15526,6 +15508,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0%]]></Text>
+					<TextCode><![CDATA[sl_mobilityDemandCompanyReduction.getIntValue() + "%"]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -15549,15 +15532,9 @@ f_setSimulateYearScreen();]]></ActionCode>
 						<ActionCode><![CDATA[//Slider function
 f_setHydrogenVehicleSliders(c_ownedGridConnections.get(v_currentSelectedGCnr), OL_EnergyAssetType.HYDROGEN_VEHICLE, (int)sl_hydrogenCarsCompany.getValue());
 
-//Update slider number
-t_numberOfHydrogenCarsCompany.setText((int)sl_hydrogenCarsCompany.getValue());
-
 //Update the other two sliders aswell
 sl_electricCarsCompany.setValue(v_nbEVCars, false);
 sl_dieselCarsCompany.setValue(v_nbDieselCars, false);
-
-t_numberOfElectricCarsCompany.setText(v_nbEVCars);
-t_numberOfDieselCarsCompany.setText(v_nbDieselCars);
 
 //Set scenario to custom
 f_setScenario(2);
@@ -15610,6 +15587,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0]]></Text>
+					<TextCode><![CDATA[sl_hydrogenCarsCompany.getIntValue()]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -15633,15 +15611,9 @@ f_setSimulateYearScreen();]]></ActionCode>
 						<ActionCode><![CDATA[//Slider function
 f_setDieselVehicleSliders(c_ownedGridConnections.get(v_currentSelectedGCnr), OL_EnergyAssetType.DIESEL_VEHICLE, (int)sl_dieselCarsCompany.getValue());
 
-//Update slider number
-t_numberOfDieselCarsCompany.setText((int)sl_dieselCarsCompany.getValue());
-
 //Update the other two sliders aswell
 sl_electricCarsCompany.setValue(v_nbEVCars, false);
 sl_hydrogenCarsCompany.setValue(v_nbHydrogenCars, false);
-
-t_numberOfElectricCarsCompany.setText(v_nbEVCars);
-t_numberOfHydrogenCarsCompany.setText(v_nbHydrogenCars);
 
 //Set scenario to custom
 f_setScenario(2);
@@ -15694,6 +15666,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0]]></Text>
+					<TextCode><![CDATA[sl_dieselCarsCompany.getIntValue()]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -15734,6 +15707,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>false</ShowLabel>
 					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<VisibleCode><![CDATA[c_ownedGridConnections.size()>1 && c_ownedGridConnections.get(0).v_isActive && c_ownedGridConnections.get(1).v_isActive]]></VisibleCode>
 					<EmbeddedIcon>false</EmbeddedIcon>
 					<Z>0</Z>
 					<Rotation>0.0</Rotation>
@@ -15806,7 +15780,6 @@ f_setSimulateYearScreen();]]></ActionCode>
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[//traceln("Slider werkt nog niet volledig!!, batterij sturing werkt nog niet goed");
 f_setBattery(c_ownedGridConnections.get(v_currentSelectedGCnr), sl_batteryCompany.getValue());
-t_batteryCompany.setText(roundToInt(sl_batteryCompany.getValue()) + " kWh");
 
 //Set scenario to custom
 f_setScenario(2);
@@ -15837,6 +15810,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0 kWh]]></Text>
+					<TextCode><![CDATA[sl_batteryCompany.getIntValue() + " kWh"]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -16139,6 +16113,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0 kW]]></Text>
+					<TextCode><![CDATA[sl_rooftopPVCompany.getIntValue() + " kW"]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -16160,7 +16135,6 @@ f_setSimulateYearScreen();]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[f_setPVSystem(c_ownedGridConnections.get(v_currentSelectedGCnr), sl_rooftopPVCompany.getValue());
-t_rooftopSolarCompany.setText(roundToInt(sl_rooftopPVCompany.getValue()) + " kW");
 
 //Set scenario to custom
 f_setScenario(2);
@@ -16212,6 +16186,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
 					<Text><![CDATA[0 kW]]></Text>
+					<TextCode><![CDATA[sl_GCCapacityCompany_Feedin.getIntValue() + " kW"]]></TextCode>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -16233,7 +16208,6 @@ f_setSimulateYearScreen();]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[f_setGCCapacity(c_ownedGridConnections.get(v_currentSelectedGCnr), sl_GCCapacityCompany_Feedin.getValue(), "FEEDIN");
-t_GCCapacityCompany_Feedin.setText(roundToInt(sl_GCCapacityCompany_Feedin.getValue()) + " kW");
 
 //Set scenario to custom
 f_setScenario(2);
@@ -16288,7 +16262,9 @@ f_setSimulateYearScreen();]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<TextColor/>
 						<Enabled>true</Enabled>
-						<ActionCode><![CDATA[zero_Interface.va_Interface.navigateTo();]]></ActionCode>
+						<ActionCode><![CDATA[zero_Interface.uI_Results.getCheckbox_KPISummary().setSelected(false, true);
+
+zero_Interface.va_Interface.navigateTo();]]></ActionCode>
 					</BasicProperties>
 					<ExtendedProperties>
 						<Font Name="Dialog" Size="14" Style="0"/>
@@ -16881,6 +16857,32 @@ zero_Interface.b_resultsUpToDate = true;
 					<FillColorCode><![CDATA[v_loadScreenColor]]></FillColorCode>
 					<FillMaterial>null</FillMaterial>
 				</Rectangle>
+				<Rectangle>
+					<Id>1729516584700</Id>
+					<Name><![CDATA[rect_GCisPausedScreen3]]></Name>
+					<X>-1980</X><Y>-60</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<VisibleCode><![CDATA[!c_ownedGridConnections.get(v_currentSelectedGCnr).v_isActive]]></VisibleCode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>2</LineWidth>
+					<LineWidthCode><![CDATA[v_chartLineWidth+0.5]]></LineWidthCode>
+					<LineColor>-6943</LineColor>
+					<LineColorCode><![CDATA[v_companyUIBackgroundColor]]></LineColorCode>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>460</Width>
+					<Height>740</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillColorCode><![CDATA[v_companyUIBackgroundColor]]></FillColorCode>
+					<FillMaterial>null</FillMaterial>
+				</Rectangle>
 				<Group>
 					<Id>1725606744485</Id>
 					<Name><![CDATA[gr_loadIconText]]></Name>
@@ -17001,7 +17003,7 @@ f_setSimulateYearScreen();]]></ActionCode>
 				<Text>
 					<Id>1727883464770</Id>
 					<Name><![CDATA[txt_nfatoValues]]></Name>
-					<X>-420</X><Y>1020</Y>
+					<X>-420</X><Y>900</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -17439,6 +17441,198 @@ f_setSimulateYearScreen();]]></ActionCode>
 			</Presentation>
 
 				</Group>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1729511748859</Id>
+					<Name><![CDATA[gr_GCisPausedScreen]]></Name>
+					<ExcludeFromBuild>true</ExcludeFromBuild>
+					<X>4480</X><Y>920</Y>
+					<Label><X>22.522</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>false</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Lock>true</Lock>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<XCode><![CDATA[1375]]></XCode>
+					<YCode><![CDATA[540]]></YCode>
+					<VisibleCode><![CDATA[!c_ownedGridConnections.get(v_currentSelectedGCnr).v_isActive]]></VisibleCode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<Rectangle>
+					<Id>1729511748861</Id>
+					<Name><![CDATA[rect_GCisPausedScreen]]></Name>
+					<X>-995</X><Y>-320</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>2</LineWidth>
+					<LineWidthCode><![CDATA[v_chartLineWidth+0.5]]></LineWidthCode>
+					<LineColor>-369756683</LineColor>
+					<LineColorCode><![CDATA[v_loadScreenColor]]></LineColorCode>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>530</Width>
+					<Height>740</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-369756683</FillColor>
+					<FillColorCode><![CDATA[v_loadScreenColor]]></FillColorCode>
+					<FillMaterial>null</FillMaterial>
+				</Rectangle>
+				<Rectangle>
+					<Id>1729511748863</Id>
+					<Name><![CDATA[rect_GCisPausedScreen2]]></Name>
+					<X>-535</X><Y>-320</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>2</LineWidth>
+					<LineWidthCode><![CDATA[v_chartLineWidth+0.5]]></LineWidthCode>
+					<LineColor>-6943</LineColor>
+					<LineColorCode><![CDATA[v_companyUIBackgroundColor]]></LineColorCode>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>1060</Width>
+					<Height>740</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillColorCode><![CDATA[v_companyUIBackgroundColor]]></FillColorCode>
+					<FillMaterial>null</FillMaterial>
+				</Rectangle>
+				<Group>
+					<Id>1729511748865</Id>
+					<Name><![CDATA[gr_GCisPausedScreenText]]></Name>
+					<X>-35</X><Y>40</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<OnClickCode><![CDATA[//Set correct overlay
+gr_simulateYearScreen.setVisible(false);		
+gr_loadIcon.setVisible(true);
+
+//Unpause gc
+c_ownedGridConnections.get(v_currentSelectedGCnr).f_setActive(true);
+
+//Select unpaused GC
+zero_Interface.f_selectBuilding(c_ownedGridConnections.get(v_currentSelectedGCnr).c_connectedGISObjects.get(0), c_ownedGridConnections.get(v_currentSelectedGCnr).c_connectedGISObjects);
+f_copyResultsUI();
+uI_Results.f_setAllCharts();
+		
+
+//Run simulation
+new Thread( () -> {	
+	//Save previous totals
+	zero_Interface.f_updatePreviousTotalsGC();
+
+	zero_Interface.energyModel.f_runRapidSimulation();
+	zero_Interface.f_updateUIresultsMainArea();
+	f_setSelectedGCGraphs();
+	gr_loadIcon.setVisible(false);
+	
+	//Update and show kpi summary chart after run
+	//uI_Results.chartKPISummary.f_setKPISummaryChart();
+	
+	//Update and show kpi summary chart after run
+	if(zero_Interface.settings.showKPISummary() != null && zero_Interface.settings.showKPISummary()){
+		uI_Results.getCheckbox_KPISummary().setSelected(true, true);
+	}
+	
+}).start();
+
+
+//Update results up to date boolean
+zero_Interface.b_resultsUpToDate = true;
+]]></OnClickCode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<Text>
+					<Id>1729511748867</Id>
+					<Name><![CDATA[t_GCisPausedScreen]]></Name>
+					<X>-140</X><Y>-80</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Onpauzeer aansluiting
+en 
+simuleer jaar voor KPI's]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>28</Size>
+						<Style>1</Style>
+					</Font>
+					<Alignment>CENTER</Alignment>
+				</Text>
+				<Image>
+					<Id>1729511748869</Id>
+					<Name><![CDATA[image_simulateYearToCalculateCostsSmall1]]></Name>
+					<X>-420</X><Y>-70</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Width>102.315</Width>
+					<Height>99.723</Height>
+					<Rotation>0.0</Rotation>
+					<ImageFiles>
+						<ImageResourceReference>
+							<PackageName><![CDATA[zerointerfaceloader]]></PackageName>
+							<ClassName><![CDATA[icon_greater_than.png]]></ClassName>
+						</ImageResourceReference>
+					</ImageFiles>
+					<OriginalSize>false</OriginalSize>
+				</Image>
+			</Presentation>
+
+				</Group>
+				<Text>
+					<Id>1729511999717</Id>
+					<Name><![CDATA[txt_GCisPaused]]></Name>
+					<X>-235</X><Y>-230</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Aansluiting is gepauzeerd!]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>72</Size>
+						<Style>1</Style>
+					</Font>
+					<Alignment>CENTER</Alignment>
+				</Text>
 			</Presentation>
 
 				</Group>
@@ -22152,6 +22346,53 @@ public ShapeSlider getSliderFossilFuelCars_pct() {
 			</ScaleRuler>
 			<CurrentLevel>1722245324902</CurrentLevel>
 			<ConnectionsId>1722245324896</ConnectionsId>
+			<Variables>
+				<Variable Class="PlainVariable">
+					<Id>1729167973194</Id>
+					<Name><![CDATA[v_totalNumberOfGhostVehicle_Trucks]]></Name>
+					<X>40</X><Y>1060</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[int]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[0]]></Code>
+						</InitialValue>
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1729168015819</Id>
+					<Name><![CDATA[v_totalNumberOfGhostVehicle_Vans]]></Name>
+					<X>40</X><Y>1040</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[int]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[0]]></Code>
+						</InitialValue>
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1729168016768</Id>
+					<Name><![CDATA[v_totalNumberOfGhostVehicle_Cars]]></Name>
+					<X>40</X><Y>1020</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[int]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[0]]></Code>
+						</InitialValue>
+					</Properties>
+				</Variable>
+			</Variables>
 			<Functions>
 				<Function AccessType="protected" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
@@ -22168,117 +22409,166 @@ public ShapeSlider getSliderFossilFuelCars_pct() {
 						<Name><![CDATA[pctElectricTrucksGoal]]></Name>
 						<Type><![CDATA[double]]></Type>
 					</Parameter>
-					<Body><![CDATA[
-
-int nbEtruckCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.ELECTRIC_TRUCK);
-int nbDieseltrucksCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.DIESEL_TRUCK);
-int nbElectricTrucksGoal = (int) ((nbEtruckCurrent + nbDieseltrucksCurrent)*pctElectricTrucksGoal/100.0);
+					<Parameter>
+						<Name><![CDATA[sliderElectricTrucks]]></Name>
+						<Type><![CDATA[ShapeSlider]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[sliderFFTrucks]]></Name>
+						<Type><![CDATA[ShapeSlider]]></Type>
+					</Parameter>
+					<Body><![CDATA[//Get totals
+int nbEtruckCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.ELECTRIC_TRUCK && !(p.getParentAgent() instanceof GCPublicCharger) && ((GridConnection)p.getParentAgent()).v_isActive) + v_totalNumberOfGhostVehicle_Trucks;
+int nbDieseltrucksCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.DIESEL_TRUCK && ((GridConnection)p.getParentAgent()).v_isActive);
+int nbElectricTrucksGoal = roundToInt((nbEtruckCurrent + nbDieseltrucksCurrent)*pctElectricTrucksGoal/100.0);
 //traceln("%s diesel trucks and %s eTrucks found", nbDieseltrucksCurrent, nbEtruckCurrent);
 
+//Remember how much vehicles there are initially
+int total_vehicles = nbEtruckCurrent + nbDieseltrucksCurrent;
+//traceln(total_vehicles);
 
 if( nbEtruckCurrent > nbElectricTrucksGoal){
 	while ( nbEtruckCurrent > nbElectricTrucksGoal && nbEtruckCurrent > 0) { // remove excess EVs systems !!!! Should also add diesel vehicle again!
-		J_EAEV ev = (J_EAEV)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_TRUCK );
+		J_EAEV ev = (J_EAEV)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_TRUCK && ((GridConnection)p.getParentAgent()).v_isActive);
 		if (ev!=null) {
 			//traceln("Found eTrucks: " + ev);
 			GridConnection gc = (GridConnection)ev.getParentAgent();
 			
 			// update UI company
-			if(zero_Interface.c_companyUIs.size() > 0){
-			UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
-			//if (companyUI.c_ownedGridConnections.get(0) == gc) { // should also check the setting of selected GC
-				int nbGCElectricTrucks = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_TRUCK);
-				int nbGCDieselTrucks = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_TRUCK);
-				if (companyUI.v_minEVTruckSlider >= nbGCElectricTrucks) {
-					traceln("Removed already existing Electric Truck");
+			UI_company companyUI = null;
+			boolean isAdditionalVehicle = false;
+			if (zero_Interface.c_companyUIs.size()>0){
+				companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
+				if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == gc) { // should also check the setting of selected GC
+					int ghostTrucks = 0;
+					if(gc.v_hasQuarterHourlyValues){
+						ghostTrucks = companyUI.v_minEVTruckSlider;
+					}
+					
+					int nbGCElectricTrucks = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_TRUCK) + ghostTrucks;
+					int nbGCDieselTrucks = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_TRUCK);
+					if (companyUI.v_minEVTruckSlider >= nbGCElectricTrucks) {
+						traceln("Removed already existing Electric Truck from GC: " + companyUI.p_companyName);
+					}
+					else {
+						companyUI.sl_electricTrucksCompany.setValue(nbGCElectricTrucks-1, false);
+						companyUI.v_nbEVTrucks--;
+						companyUI.sl_dieselTrucksCompany.setValue(nbGCDieselTrucks+1, false);
+						companyUI.v_nbDieselTrucks++;
+					}
+					companyUI.rb_scenariosPrivateUI.setValue(2, false);
+					
 				}
-				else {
-					companyUI.sl_electricTrucksCompany.setValue(nbGCElectricTrucks-1, false);
-					companyUI.t_numberOfElectricTrucksCompany.setText(nbGCElectricTrucks-1);
-					companyUI.v_nbEVTrucks--;
-					companyUI.sl_dieselTrucksCompany.setValue(nbGCDieselTrucks+1, false);
-					companyUI.t_numberOfDieselTrucksCompany.setText(nbGCDieselTrucks+1);
-					companyUI.v_nbDieselTrucks++;
+				if(companyUI != null){
+					for(GridConnection GC: companyUI.c_ownedGridConnections){
+						if(companyUI.c_additionalVehicles.get(GC).contains(ev)){
+							companyUI.c_additionalVehicles.get(GC).remove(ev);
+							isAdditionalVehicle = true;
+						}
+					}
 				}
-			//}
 			}
 			
 			J_ActivityTrackerTrips tripTracker = ev.tripTracker;
 			boolean available = true;
-			//h.c_storageAssets.remove(EA);
 			available = ev.getAvailability();
 			zero_Interface.c_orderedVehicles.remove(ev);
 			ev.removeEnergyAsset();
 			//traceln("Removing EV from gridConnection:" + GC.p_gridConnectionID);
 		
 			// Re-add diesel vehicle
-			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgDieselConsumptionTruck_kWhpkm;//g.required( "energyConsumption_kWhpkm" ).doubleValue();
-			double vehicleScaling = 1.0;//g.hasNonNull("vehicleScaling")? g.required("vehicleScaling").doubleValue() : 1.0;		
+			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgDieselConsumptionTruck_kWhpkm;
+			double vehicleScaling = 1.0;
 			J_EADieselVehicle dieselVehicle = new J_EADieselVehicle(gc, energyConsumption_kWhpkm, zero_Interface.energyModel.p_timeStep_h, vehicleScaling, OL_EnergyAssetType.DIESEL_TRUCK, tripTracker);
 			dieselVehicle.available = available;
 			
 			zero_Interface.c_orderedVehicles.add(0, dieselVehicle);
 			
-			nbEtruckCurrent--; // = count(energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.ELECTRIC_TRUCK);
-			nbDieseltrucksCurrent++; // = count(energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.DIESEL_TRUCK);
+			//check if was additional vehicle in companyUI, if so: add to collection
+			if(companyUI != null && isAdditionalVehicle){
+				companyUI.c_additionalVehicles.get(gc).add(dieselVehicle);
+			}
+			
+			nbEtruckCurrent--; 
+			nbDieseltrucksCurrent++;
+		}
+		else{//No more vehicles to adjust: this is the minimum: set slider to minimum and do nothing else
+				int total_electricTrucks = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.ELECTRIC_TRUCK && !(p.getParentAgent() instanceof GCPublicCharger)  && ((GridConnection)p.getParentAgent()).v_isActive) + v_totalNumberOfGhostVehicle_Trucks;
+				int min_pct_electricTruckSlider = roundToInt(100.0*total_electricTrucks/total_vehicles);
+				sliderElectricTrucks.setValue(min_pct_electricTruckSlider, false);
+				sliderFFTrucks.setValue(100-min_pct_electricTruckSlider, false);
+			return;
 		}
 	} 
 } else { 
 	while ( nbEtruckCurrent < nbElectricTrucksGoal && nbDieseltrucksCurrent > 0) {
+	
+		
 		// Remove diesel vehicle
-		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_TRUCK );
+		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_TRUCK && ((GridConnection)p.getParentAgent()).v_isActive);
 		//traceln("Found diesel vehicle: " + dieselVehicle);
 		if (dieselVehicle!=null) {
 			GridConnection gc = (GridConnection)dieselVehicle.getParentAgent();
 			
 			
 			// update UI company
-			if(zero_Interface.c_companyUIs.size() > 0){
-			UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
-			//if (companyUI.c_ownedGridConnections.get(0) == gc) { // should also check the setting of selected GC
-				int nbGCElectricTrucks = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_TRUCK);
-				int nbGCDieselTrucks = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_TRUCK);
-				companyUI.sl_electricTrucksCompany.setValue(nbGCElectricTrucks+1, false);
-				companyUI.t_numberOfElectricTrucksCompany.setText(nbGCElectricTrucks+1);	
-				companyUI.v_nbEVTrucks++;
-				companyUI.sl_dieselTrucksCompany.setValue(nbGCDieselTrucks-1, false);
-				companyUI.t_numberOfDieselTrucksCompany.setText(nbGCDieselTrucks-1);
-				companyUI.v_nbDieselTrucks--;
-			//}
+			UI_company companyUI = null;
+			boolean isAdditionalVehicle = false;
+			if (zero_Interface.c_companyUIs.size()>0){
+				companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
+				if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == gc) { // should also check the setting of selected GC
+					int ghostTrucks = 0;
+					if(gc.v_hasQuarterHourlyValues){
+						ghostTrucks = companyUI.v_minEVTruckSlider;
+					}
+					int nbGCElectricTrucks = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_TRUCK) + ghostTrucks;
+					int nbGCDieselTrucks = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_TRUCK);
+					companyUI.sl_electricTrucksCompany.setValue(nbGCElectricTrucks+1, false);
+					companyUI.v_nbEVTrucks++;
+					companyUI.sl_dieselTrucksCompany.setValue(nbGCDieselTrucks-1, false);
+					companyUI.v_nbDieselTrucks--;
+					companyUI.rb_scenariosPrivateUI.setValue(2, false);
+				}
+				if(companyUI != null){
+					for(GridConnection GC: companyUI.c_ownedGridConnections){
+						if(companyUI.c_additionalVehicles.get(GC).contains(dieselVehicle)){
+							companyUI.c_additionalVehicles.get(GC).remove(dieselVehicle);
+							isAdditionalVehicle = true;
+						}
+					}
+				}
 			}
+			
 			J_ActivityTrackerTrips tripTracker = dieselVehicle.tripTracker;
 			boolean available = true;
-			//h.c_consumptionAssets.remove(dieselVehicle);
 			available = dieselVehicle.getAvailability();
 			zero_Interface.c_orderedVehicles.remove(dieselVehicle);
 			dieselVehicle.removeEnergyAsset();
 			//traceln("Removing household DIESEL VEHICLE from household:" + GC.p_gridConnectionID);
 	
-			// Re-add EV
-			//EnergyAsset storageAsset = add_pop_energyAssets();
-			//storageAsset.set_p_parentAgentID( h.p_gridConnectionID );
-			//storageAsset.set_p_energyAssetType( OL_EnergyAssetType.valueOf(t.required( "type" ).textValue() ));
-			//storageAsset.set_p_defaultEnergyAssetPresetName( t.required( "name" ).textValue());
-	
-			double capacityElectric_kW = zero_Interface.energyModel.avgc_data.p_avgEVMaxChargePowerTruck_kW;//t.required( "capacityElectricity_kW").doubleValue();
-			double storageCapacity_kWh = zero_Interface.energyModel.avgc_data.p_avgEVStorageTruck_kWh;//t.required( "storageCapacity_kWh" ).doubleValue();
-			double initialStateOfCharge_r = 1.0;//t.required( "stateOfCharge_r" ).doubleValue();
-			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgEVEnergyConsumptionTruck_kWhpkm;//t.required( "energyConsumption_kWhpkm" ).doubleValue();
-			double vehicleScalingElectric = 1.0;//t.hasNonNull("vehicleScaling")? t.required("vehicleScaling").doubleValue() : 1.0;
+			double capacityElectric_kW = zero_Interface.energyModel.avgc_data.p_avgEVMaxChargePowerTruck_kW;
+			double storageCapacity_kWh = zero_Interface.energyModel.avgc_data.p_avgEVStorageTruck_kWh;
+			double initialStateOfCharge_r = 1.0;
+			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgEVEnergyConsumptionTruck_kWhpkm;
+			double vehicleScalingElectric = 1.0;
 			J_EAEV ev = new J_EAEV(gc, capacityElectric_kW, storageCapacity_kWh, initialStateOfCharge_r, zero_Interface.energyModel.p_timeStep_h, energyConsumption_kWhpkm, vehicleScalingElectric, OL_EnergyAssetType.ELECTRIC_TRUCK, tripTracker);  
-			//ev.energyAssetType = OL_EnergyAssetType.ELECTRIC_TRUCK;
 			ev.available = available;
 			
 			zero_Interface.c_orderedVehicles.add(0, ev);	
 			
-			nbEtruckCurrent++; // = count(energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.ELECTRIC_TRUCK);
-			nbDieseltrucksCurrent--; // = count(energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.DIESEL_TRUCK);
+			//check if was additional vehicle in companyUI, if so: add to collection
+			if(companyUI != null && isAdditionalVehicle){
+				companyUI.c_additionalVehicles.get(gc).add(ev);
+			}
+			
+			nbEtruckCurrent++; 
+			nbDieseltrucksCurrent--;
 		}
 	}
 	
 }	
 
-traceln("%s diesel trucks and %s eTrucks: ", nbDieseltrucksCurrent, nbEtruckCurrent);
+//traceln("%s diesel trucks and %s eTrucks: ", nbDieseltrucksCurrent, nbEtruckCurrent);
 zero_Interface.f_resetSettings();]]></Body>
 				</Function>
 				<Function AccessType="protected" StaticFunction="false">
@@ -22351,106 +22641,155 @@ if (hydrogenSlider != null) {
 						<Name><![CDATA[pctElectricVansGoal]]></Name>
 						<Type><![CDATA[double]]></Type>
 					</Parameter>
-					<Body><![CDATA[int nbEVansCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VAN);
-int nbDieselVansCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.DIESEL_VAN);
-int nbElectricVansGoal = (int) ((nbEVansCurrent + nbDieselVansCurrent)*pctElectricVansGoal/100.0);
+					<Parameter>
+						<Name><![CDATA[sliderElectricVans]]></Name>
+						<Type><![CDATA[ShapeSlider]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[sliderFFVans]]></Name>
+						<Type><![CDATA[ShapeSlider]]></Type>
+					</Parameter>
+					<Body><![CDATA[int nbEVansCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VAN && !(p.getParentAgent() instanceof GCPublicCharger) && ((GridConnection)p.getParentAgent()).v_isActive) + v_totalNumberOfGhostVehicle_Vans;
+int nbDieselVansCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.DIESEL_VAN && ((GridConnection)p.getParentAgent()).v_isActive);
+int nbElectricVansGoal = roundToInt((nbEVansCurrent + nbDieselVansCurrent)*pctElectricVansGoal/100.0);
+
+//Remember how much vehicles there are initially
+int total_vehicles = nbEVansCurrent + nbDieselVansCurrent;
 
 
 if( nbEVansCurrent > nbElectricVansGoal){
 	while ( nbEVansCurrent > nbElectricVansGoal && nbEVansCurrent > 0) { // remove excess EVs systems !!!! Should also add diesel vehicle again!
-		J_EAEV ev = (J_EAEV)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VAN );
+		J_EAEV ev = (J_EAEV)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VAN && ((GridConnection)p.getParentAgent()).v_isActive);
 		if (ev!=null) {
 			//traceln("Found eTrucks: " + ev);
 			GridConnection gc = (GridConnection)ev.getParentAgent();
 			
 			// update UI company
-			if(zero_Interface.c_companyUIs.size() > 0){
-			UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
-			//if (companyUI.c_ownedGridConnections.get(0) == gc) { // should also check the setting of selected GC
-				int nbGCElectricVans = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VAN);
-				int nbGCDieselVans = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VAN);
-				if (companyUI.v_minEVVanSlider >= nbGCElectricVans) {
-					traceln("Removed already existing Electric Van");
+			UI_company companyUI = null;
+			boolean isAdditionalVehicle = false;
+			if (zero_Interface.c_companyUIs.size()>0){
+				companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
+				if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == gc) { // should also check the setting of selected GC
+					int ghostVans = 0;
+					if(gc.v_hasQuarterHourlyValues){
+						ghostVans = companyUI.v_minEVVanSlider;
+					}
+					
+					int nbGCElectricVans = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VAN) + ghostVans;
+					int nbGCDieselVans = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VAN);
+					if (companyUI.v_minEVVanSlider >= nbGCElectricVans) {
+						traceln("Removed already existing Electric Van from GC: " + companyUI.p_companyName);
+					}
+					else {
+						companyUI.sl_electricVansCompany.setValue(nbGCElectricVans-1, false);
+						companyUI.v_nbEVVans--;
+						companyUI.sl_dieselVansCompany.setValue(nbGCDieselVans+1, false);
+						companyUI.v_nbDieselVans++;
+					}
+					companyUI.rb_scenariosPrivateUI.setValue(2, false);
 				}
-				else {
-					companyUI.sl_electricVansCompany.setValue(nbGCElectricVans-1, false);
-					companyUI.t_numberOfElectricVansCompany.setText(nbGCElectricVans-1);
-					companyUI.v_nbEVVans--;
-					companyUI.sl_dieselVansCompany.setValue(nbGCDieselVans+1, false);
-					companyUI.t_numberOfDieselVansCompany.setText(nbGCDieselVans+1);
-					companyUI.v_nbDieselVans++;
+				if(companyUI != null){
+					for(GridConnection GC: companyUI.c_ownedGridConnections){
+						if(companyUI.c_additionalVehicles.get(GC).contains(ev)){
+							companyUI.c_additionalVehicles.get(GC).remove(ev);
+							isAdditionalVehicle = true;
+						}
+					}
 				}
-			//}
 			}
 			
 			J_ActivityTrackerTrips tripTracker = ev.tripTracker;
 			boolean available = true;
-			//h.c_storageAssets.remove(EA);
 			available = ev.getAvailability();
 			zero_Interface.c_orderedVehicles.remove(ev);
 			ev.removeEnergyAsset();
 			//traceln("Removing EV from gridConnection:" + GC.p_gridConnectionID);
 		
 			// Re-add diesel vehicle
-			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgDieselConsumptionVan_kWhpkm;//g.required( "energyConsumption_kWhpkm" ).doubleValue();
-			double vehicleScaling = 1.0;//g.hasNonNull("vehicleScaling")? g.required("vehicleScaling").doubleValue() : 1.0;		
+			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgDieselConsumptionVan_kWhpkm;
+			double vehicleScaling = 1.0;
 			J_EADieselVehicle dieselVehicle = new J_EADieselVehicle(gc, energyConsumption_kWhpkm, zero_Interface.energyModel.p_timeStep_h, vehicleScaling, OL_EnergyAssetType.DIESEL_VAN, tripTracker);
 			dieselVehicle.available = available;
 			
 			zero_Interface.c_orderedVehicles.add(0, dieselVehicle);
+
+			//check if was additional vehicle in companyUI, if so: add to collection
+			if(companyUI != null && isAdditionalVehicle){
+				companyUI.c_additionalVehicles.get(gc).add(dieselVehicle);
+			}
 			
 			nbEVansCurrent--;
 			nbDieselVansCurrent++;
 		}
+		else{//No more vehicles to adjust: this is the minimum: set slider to minimum and do nothing else
+			int total_electricVans = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VAN && !(p.getParentAgent() instanceof GCPublicCharger)  && ((GridConnection)p.getParentAgent()).v_isActive) + v_totalNumberOfGhostVehicle_Vans;
+			int min_pct_electricVanSlider = roundToInt(100.0*total_electricVans/total_vehicles);
+			sliderElectricVans.setValue(min_pct_electricVanSlider, false);
+			sliderFFVans.setValue(100-min_pct_electricVanSlider, false);
+			return;
+		}
 	} 
 } else { 
 	while ( nbEVansCurrent < nbElectricVansGoal && nbDieselVansCurrent > 0) {
+
 		// Remove diesel vehicle
-		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VAN );
+		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VAN && ((GridConnection)p.getParentAgent()).v_isActive);
 		//traceln("Found diesel vehicle: " + dieselVehicle);
 		if (dieselVehicle!=null) {
 			GridConnection gc = (GridConnection)dieselVehicle.getParentAgent();
 			
 			
 			// update UI company
-			if(zero_Interface.c_companyUIs.size() > 0){
-			UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
-			//if (companyUI.c_ownedGridConnections.get(0) == gc) { // should also check the setting of selected GC
-				int nbGCElectricVans = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VAN);
-				int nbGCDieselVans = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VAN);
-				companyUI.sl_electricVansCompany.setValue(nbGCElectricVans+1, false);
-				companyUI.t_numberOfElectricVansCompany.setText(nbGCElectricVans+1);	
-				companyUI.v_nbEVVans++;
-				companyUI.sl_dieselVansCompany.setValue(nbGCDieselVans-1, false);
-				companyUI.t_numberOfDieselVansCompany.setText(nbGCDieselVans-1);
-				companyUI.v_nbDieselVans--;
-			//}
+			UI_company companyUI = null;
+			boolean isAdditionalVehicle = false;
+			if (zero_Interface.c_companyUIs.size()>0){
+				companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
+				if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == gc) { // should also check the setting of selected GC
+					int ghostVans = 0;
+					if(gc.v_hasQuarterHourlyValues){
+						ghostVans = companyUI.v_minEVVanSlider;
+					}
+					
+					int nbGCElectricVans = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VAN) + ghostVans;
+					int nbGCDieselVans = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VAN);
+					companyUI.sl_electricVansCompany.setValue(nbGCElectricVans+1, false);	
+					companyUI.v_nbEVVans++;
+					companyUI.sl_dieselVansCompany.setValue(nbGCDieselVans-1, false);
+					companyUI.v_nbDieselVans--;
+					companyUI.rb_scenariosPrivateUI.setValue(2, false);
+				}
+				if(companyUI != null){
+					for(GridConnection GC: companyUI.c_ownedGridConnections){
+						if(companyUI.c_additionalVehicles.get(GC).contains(dieselVehicle)){
+							companyUI.c_additionalVehicles.get(GC).remove(dieselVehicle);
+							isAdditionalVehicle = true;
+						}
+					}
+				}
 			}
 			
 			J_ActivityTrackerTrips tripTracker = dieselVehicle.tripTracker;
 			boolean available = true;
-			//h.c_consumptionAssets.remove(dieselVehicle);
 			available = dieselVehicle.getAvailability();
 			zero_Interface.c_orderedVehicles.remove(dieselVehicle);
 			dieselVehicle.removeEnergyAsset();
 			//traceln("Removing household DIESEL VEHICLE from household:" + GC.p_gridConnectionID);
-	
-			// Re-add EV
-			//EnergyAsset storageAsset = add_pop_energyAssets();
-			//storageAsset.set_p_parentAgentID( h.p_gridConnectionID );
-			//storageAsset.set_p_energyAssetType( OL_EnergyAssetType.valueOf(t.required( "type" ).textValue() ));
-			//storageAsset.set_p_defaultEnergyAssetPresetName( t.required( "name" ).textValue());
-	
-			double capacityElectric_kW = zero_Interface.energyModel.avgc_data.p_avgEVMaxChargePowerVan_kW;//t.required( "capacityElectricity_kW").doubleValue();
-			double storageCapacity_kWh = zero_Interface.energyModel.avgc_data.p_avgEVStorageVan_kWh;//t.required( "storageCapacity_kWh" ).doubleValue();
-			double initialStateOfCharge_r = 1.0;//t.required( "stateOfCharge_r" ).doubleValue();
-			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgEVEnergyConsumptionVan_kWhpkm;//t.required( "energyConsumption_kWhpkm" ).doubleValue();
-			double vehicleScalingElectric = 1.0;//t.hasNonNull("vehicleScaling")? t.required("vehicleScaling").doubleValue() : 1.0;
+			
+			double capacityElectric_kW = zero_Interface.energyModel.avgc_data.p_avgEVMaxChargePowerVan_kW;
+			double storageCapacity_kWh = zero_Interface.energyModel.avgc_data.p_avgEVStorageVan_kWh;
+			double initialStateOfCharge_r = 1.0;
+			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgEVEnergyConsumptionVan_kWhpkm;
+			double vehicleScalingElectric = 1.0;
 			J_EAEV ev = new J_EAEV(gc, capacityElectric_kW, storageCapacity_kWh, initialStateOfCharge_r, zero_Interface.energyModel.p_timeStep_h, energyConsumption_kWhpkm, vehicleScalingElectric, OL_EnergyAssetType.ELECTRIC_VAN, tripTracker);  
-			//ev.energyAssetType = OL_EnergyAssetType.ELECTRIC_TRUCK;
+
 			ev.available = available;
 			
 			zero_Interface.c_orderedVehicles.add(0, ev);	
+			
+			//check if was additional vehicle in companyUI, if so: add to collection
+			if(companyUI != null && isAdditionalVehicle){
+				companyUI.c_additionalVehicles.get(gc).add(ev);
+			}
 			
 			nbEVansCurrent++;
 			nbDieselVansCurrent--;
@@ -22459,7 +22798,7 @@ if( nbEVansCurrent > nbElectricVansGoal){
 	
 }	
 
-traceln("%s diesel vans and %s EVans: ", nbDieselVansCurrent, nbEVansCurrent);
+//traceln("%s diesel vans and %s EVans: ", nbDieselVansCurrent, nbEVansCurrent);
 zero_Interface.f_resetSettings();]]></Body>
 				</Function>
 				<Function AccessType="protected" StaticFunction="false">
@@ -22477,106 +22816,154 @@ zero_Interface.f_resetSettings();]]></Body>
 						<Name><![CDATA[pctEVsGoal]]></Name>
 						<Type><![CDATA[double]]></Type>
 					</Parameter>
-					<Body><![CDATA[int nbEVsCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VEHICLE);
-int nbDieselCarsCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.DIESEL_VEHICLE);
-int nbEVsGoal = (int) ((nbEVsCurrent + nbDieselCarsCurrent)*pctEVsGoal/100.0);
+					<Parameter>
+						<Name><![CDATA[sliderElectricCars]]></Name>
+						<Type><![CDATA[ShapeSlider]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[sliderFFCars]]></Name>
+						<Type><![CDATA[ShapeSlider]]></Type>
+					</Parameter>
+					<Body><![CDATA[int nbEVsCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VEHICLE && !(p.getParentAgent() instanceof GCPublicCharger) && ((GridConnection)p.getParentAgent()).v_isActive) + v_totalNumberOfGhostVehicle_Cars;
+int nbDieselCarsCurrent = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.DIESEL_VEHICLE && ((GridConnection)p.getParentAgent()).v_isActive);
+int nbEVsGoal = roundToInt((nbEVsCurrent + nbDieselCarsCurrent)*pctEVsGoal/100.0);
 
+//Remember how much vehicles there are initially
+int total_vehicles = nbEVsCurrent + nbDieselCarsCurrent;
 
 if( nbEVsCurrent > nbEVsGoal){
 	while ( nbEVsCurrent > nbEVsGoal && nbEVsCurrent > 0) { // remove excess EVs systems !!!! Should also add diesel vehicle again!
-		J_EAEV ev = (J_EAEV)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VEHICLE );
+		J_EAEV ev = (J_EAEV)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VEHICLE && ((GridConnection)p.getParentAgent()).v_isActive);
 		if (ev!=null) {
 			//traceln("Found eTrucks: " + ev);
 			GridConnection gc = (GridConnection)ev.getParentAgent();
 			
 			// update UI company
-			if(zero_Interface.c_companyUIs.size() > 0){
-			UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
-			//if (companyUI.c_ownedGridConnections.get(0) == gc) { // should also check the setting of selected GC
-				int nbGCEVs = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VEHICLE);
-				int nbGCDieselCars = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VEHICLE);
-				if (companyUI.v_minEVCarSlider >= nbGCEVs) {
-					traceln("Removed already existing Electric Car");
+			UI_company companyUI = null;
+			boolean isAdditionalVehicle = false;
+			if (zero_Interface.c_companyUIs.size()>0){
+				companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
+				if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == gc) { // should also check the setting of selected GC
+					
+					int ghostCars = 0;
+					if(gc.v_hasQuarterHourlyValues){
+						ghostCars = companyUI.v_minEVCarSlider;
+					}
+					
+					int nbGCEVs = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VEHICLE) + ghostCars;
+					int nbGCDieselCars = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VEHICLE);
+					if (companyUI.v_minEVCarSlider >= nbGCEVs) {
+						traceln("Removed already existing Electric Car from GC: " + companyUI.p_companyName);
+					}
+					else {
+						companyUI.sl_electricCarsCompany.setValue(nbGCEVs-1, false);
+						companyUI.v_nbEVCars--;
+						companyUI.sl_dieselCarsCompany.setValue(nbGCDieselCars+1, false);
+						companyUI.v_nbDieselCars++;
+					}
+					companyUI.rb_scenariosPrivateUI.setValue(2, false);
 				}
-				else {
-					companyUI.sl_electricCarsCompany.setValue(nbGCEVs-1, false);
-					companyUI.t_numberOfElectricCarsCompany.setText(nbGCEVs-1);
-					companyUI.v_nbEVCars--;
-					companyUI.sl_dieselCarsCompany.setValue(nbGCDieselCars+1, false);
-					companyUI.t_numberOfDieselCarsCompany.setText(nbGCDieselCars+1);
-					companyUI.v_nbDieselCars++;
+				if(companyUI != null){
+					for(GridConnection GC: companyUI.c_ownedGridConnections){
+						if(companyUI.c_additionalVehicles.get(GC).contains(ev)){
+							companyUI.c_additionalVehicles.get(GC).remove(ev);
+							isAdditionalVehicle = true;		
+						}
+					}
 				}
-			//}
 			}
-			
+		
 			J_ActivityTrackerTrips tripTracker = ev.tripTracker;
 			boolean available = true;
-			//h.c_storageAssets.remove(EA);
 			available = ev.getAvailability();
 			zero_Interface.c_orderedVehicles.remove(ev);
 			ev.removeEnergyAsset();
 			//traceln("Removing EV from gridConnection:" + GC.p_gridConnectionID);
 		
 			// Re-add diesel vehicle
-			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgDieselConsumptionCar_kWhpkm;//g.required( "energyConsumption_kWhpkm" ).doubleValue();
-			double vehicleScaling = 1.0;//g.hasNonNull("vehicleScaling")? g.required("vehicleScaling").doubleValue() : 1.0;		
+			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgDieselConsumptionCar_kWhpkm;
+			double vehicleScaling = 1.0;	
 			J_EADieselVehicle dieselVehicle = new J_EADieselVehicle(gc, energyConsumption_kWhpkm, zero_Interface.energyModel.p_timeStep_h, vehicleScaling, OL_EnergyAssetType.DIESEL_VEHICLE, tripTracker);
 			dieselVehicle.available = available;
 			
-			zero_Interface.c_orderedVehicles.add(0, dieselVehicle);
+			zero_Interface.c_orderedVehicles.add(0, dieselVehicle);	
+				
+			//check if was additional vehicle in companyUI, if so: add to collection
+			if(companyUI != null && isAdditionalVehicle){
+				companyUI.c_additionalVehicles.get(gc).add(dieselVehicle);
+			}
 			
 			nbEVsCurrent--;
 			nbDieselCarsCurrent++;
+		}
+		else{//No more vehicles to adjust: this is the minimum: set slider to minimum and do nothing else
+				int total_electricCars = count(zero_Interface.energyModel.f_getEnergyAssets(), p->p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VEHICLE && !(p.getParentAgent() instanceof GCPublicCharger)  && ((GridConnection)p.getParentAgent()).v_isActive) + v_totalNumberOfGhostVehicle_Cars;
+				int min_pct_electricCarSlider = roundToInt(100.0*total_electricCars/total_vehicles);
+				sliderElectricCars.setValue(min_pct_electricCarSlider, false);
+				sliderFFCars.setValue(100-min_pct_electricCarSlider, false);
+			return;
 		}
 	} 
 } else { 
 	while ( nbEVsCurrent < nbEVsGoal && nbDieselCarsCurrent > 0) {
 		// Remove diesel vehicle
-		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VEHICLE );
+		J_EADieselVehicle dieselVehicle = (J_EADieselVehicle)findFirst(zero_Interface.c_orderedVehicles, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VEHICLE && ((GridConnection)p.getParentAgent()).v_isActive);
 		//traceln("Found diesel vehicle: " + dieselVehicle);
 		if (dieselVehicle!=null) {
 			GridConnection gc = (GridConnection)dieselVehicle.getParentAgent();
 			
 			
 			// update UI company
-			if(zero_Interface.c_companyUIs.size() > 0){
-			UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
-			//if (companyUI.c_ownedGridConnections.get(0) == gc) { // should also check the setting of selected GC
-				int nbGCEVs = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VEHICLE);
-				int nbGCDieselCars = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VEHICLE);
-				companyUI.sl_electricCarsCompany.setValue(nbGCEVs+1, false);
-				companyUI.t_numberOfElectricCarsCompany.setText(nbGCEVs+1);	
-				companyUI.v_nbEVCars++;
-				companyUI.sl_dieselCarsCompany.setValue(nbGCDieselCars-1, false);
-				companyUI.t_numberOfDieselCarsCompany.setText(nbGCDieselCars-1);
-				companyUI.v_nbDieselCars--;
-			//}
+			UI_company companyUI = null;
+			boolean isAdditionalVehicle = false;
+			if (zero_Interface.c_companyUIs.size()>0){
+				companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
+				if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == gc) { // should also check the setting of selected GC
+					
+					int ghostCars = 0;
+					if(gc.v_hasQuarterHourlyValues){
+						ghostCars = companyUI.v_minEVCarSlider;
+					}
+					
+					int nbGCEVs = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.ELECTRIC_VEHICLE) + ghostCars;
+					int nbGCDieselCars = count(gc.c_vehicleAssets, p -> p.energyAssetType == OL_EnergyAssetType.DIESEL_VEHICLE);
+					companyUI.sl_electricCarsCompany.setValue(nbGCEVs+1, false);
+					companyUI.v_nbEVCars++;
+					companyUI.sl_dieselCarsCompany.setValue(nbGCDieselCars-1, false);
+					companyUI.v_nbDieselCars--;
+					companyUI.rb_scenariosPrivateUI.setValue(2, false);
+				}
+				if(companyUI != null){
+					for(GridConnection GC: companyUI.c_ownedGridConnections){
+						if(companyUI.c_additionalVehicles.get(GC).contains(dieselVehicle)){
+							companyUI.c_additionalVehicles.get(GC).remove(dieselVehicle);
+							isAdditionalVehicle = true;
+						}
+					}
+				}
 			}
 			
 			J_ActivityTrackerTrips tripTracker = dieselVehicle.tripTracker;
 			boolean available = true;
-			//h.c_consumptionAssets.remove(dieselVehicle);
 			available = dieselVehicle.getAvailability();
 			zero_Interface.c_orderedVehicles.remove(dieselVehicle);
 			dieselVehicle.removeEnergyAsset();
 			//traceln("Removing household DIESEL VEHICLE from household:" + GC.p_gridConnectionID);
-	
-			// Re-add EV
-			//EnergyAsset storageAsset = add_pop_energyAssets();
-			//storageAsset.set_p_parentAgentID( h.p_gridConnectionID );
-			//storageAsset.set_p_energyAssetType( OL_EnergyAssetType.valueOf(t.required( "type" ).textValue() ));
-			//storageAsset.set_p_defaultEnergyAssetPresetName( t.required( "name" ).textValue());
-	
-			double capacityElectric_kW = zero_Interface.energyModel.avgc_data.p_avgEVMaxChargePowerCar_kW;//t.required( "capacityElectricity_kW").doubleValue();
-			double storageCapacity_kWh = zero_Interface.energyModel.avgc_data.p_avgEVStorageCar_kWh;//t.required( "storageCapacity_kWh" ).doubleValue();
-			double initialStateOfCharge_r = 1.0;//t.required( "stateOfCharge_r" ).doubleValue();
-			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgEVEnergyConsumptionCar_kWhpkm;//t.required( "energyConsumption_kWhpkm" ).doubleValue();
-			double vehicleScalingElectric = 1.0;//t.hasNonNull("vehicleScaling")? t.required("vehicleScaling").doubleValue() : 1.0;
+
+			double capacityElectric_kW = zero_Interface.energyModel.avgc_data.p_avgEVMaxChargePowerCar_kW;
+			double storageCapacity_kWh = zero_Interface.energyModel.avgc_data.p_avgEVStorageCar_kWh;
+			double initialStateOfCharge_r = 1.0;
+			double energyConsumption_kWhpkm = zero_Interface.energyModel.avgc_data.p_avgEVEnergyConsumptionCar_kWhpkm;
+			double vehicleScalingElectric = 1.0;
 			J_EAEV ev = new J_EAEV(gc, capacityElectric_kW, storageCapacity_kWh, initialStateOfCharge_r, zero_Interface.energyModel.p_timeStep_h, energyConsumption_kWhpkm, vehicleScalingElectric, OL_EnergyAssetType.ELECTRIC_VEHICLE, tripTracker);  
-			//ev.energyAssetType = OL_EnergyAssetType.ELECTRIC_TRUCK;
 			ev.available = available;
 			
 			zero_Interface.c_orderedVehicles.add(0, ev);	
+
+			//check if was additional vehicle in companyUI, if so: add to collection
+			if(companyUI != null && isAdditionalVehicle){
+				companyUI.c_additionalVehicles.get(gc).add(ev);
+			}
 			
 			nbEVsCurrent++;
 			nbDieselCarsCurrent--;
@@ -22585,7 +22972,7 @@ if( nbEVsCurrent > nbEVsGoal){
 	
 }	
 
-traceln("%s diesel cars and %s EVs: ", nbDieselCarsCurrent, nbEVsCurrent);
+//traceln("%s diesel cars and %s EVs: ", nbDieselCarsCurrent, nbEVsCurrent);
 zero_Interface.f_resetSettings();]]></Body>
 				</Function>
 				<Function AccessType="protected" StaticFunction="false">
@@ -22611,10 +22998,62 @@ double mobilityDemandReduction_pct = demandReduction_pct;
 for (J_EA j_ea : zero_Interface.energyModel.f_getEnergyAssets()) {
 	if (j_ea instanceof J_EAVehicle) {
 		((J_EAVehicle)j_ea).getTripTracker().distanceScaling_fr =  1 - mobilityDemandReduction_pct/100.0;
+		if (zero_Interface.c_companyUIs.size()>0){
+			UI_company companyUI = zero_Interface.c_companyUIs.get(((GridConnection)j_ea.getParentAgent()).p_owner.p_connectionOwnerIndexNr);
+			if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == j_ea.getParentAgent()) { // should also check the setting of selected GC
+				companyUI.sl_mobilityDemandCompanyReduction.setValue(mobilityDemandReduction_pct, false);
+			}
+		}	
 	}
 }
 
 zero_Interface.f_resetSettings();]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1729168033110</Id>
+					<Name><![CDATA[f_getNumberOfGhostVehicles]]></Name>
+					<X>20</X><Y>1000</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[/*
+v_totalNumberOfGhostVehicle_Cars = 0;
+v_totalNumberOfGhostVehicle_Vans = 0;
+v_totalNumberOfGhostVehicle_Trucks = 0;
+
+for (UI_company companyUI : zero_Interface.c_companyUIs ){
+	
+	v_totalNumberOfGhostVehicle_Cars += companyUI.v_minEVCarSlider;
+	v_totalNumberOfGhostVehicle_Vans += companyUI.v_minEVVanSlider;
+	v_totalNumberOfGhostVehicle_Trucks += companyUI.v_minEVTruckSlider;
+}
+traceln("Ghost vehicles:");
+traceln(v_totalNumberOfGhostVehicle_Cars);
+traceln(v_totalNumberOfGhostVehicle_Vans);
+traceln(v_totalNumberOfGhostVehicle_Trucks);
+*/
+
+v_totalNumberOfGhostVehicle_Cars = 0;
+v_totalNumberOfGhostVehicle_Vans = 0;
+v_totalNumberOfGhostVehicle_Trucks = 0;
+for (UI_company companyUI : zero_Interface.c_companyUIs ){
+	
+	for(int i = 0; i < companyUI.c_ownedGridConnections.size(); i++){
+		if(companyUI.c_ownedGridConnections.get(i).v_hasQuarterHourlyValues && companyUI.c_ownedGridConnections.get(i).v_isActive){
+			v_totalNumberOfGhostVehicle_Cars += companyUI.v_minEVCarSlider;
+			v_totalNumberOfGhostVehicle_Vans += companyUI.v_minEVVanSlider;
+			v_totalNumberOfGhostVehicle_Trucks += companyUI.v_minEVTruckSlider;
+		}
+	}
+}
+
+//traceln(v_totalNumberOfGhostVehicle_Cars);
+//traceln(v_totalNumberOfGhostVehicle_Vans);
+//traceln(v_totalNumberOfGhostVehicle_Trucks);
+]]></Body>
 				</Function>
 			</Functions>
 			<AgentLinks>
@@ -22775,7 +23214,7 @@ zero_Interface.f_resetSettings();]]></Body>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[sl_electricCars_pct.setValue(100 - sl_fossilFuelCars_pct.getIntValue(), false);
-f_setElectricCars( sl_electricCars_pct.getValue() );]]></ActionCode>
+f_setElectricCars( sl_electricCars_pct.getValue(), sl_electricCars_pct, sl_fossilFuelCars_pct );]]></ActionCode>
 					</BasicProperties>
 					<ExtendedProperties>
 						<DefaultValueCode><![CDATA[0]]></DefaultValueCode>
@@ -22800,7 +23239,7 @@ f_setElectricCars( sl_electricCars_pct.getValue() );]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[f_setVehicleSliders( 0, sl_electricTrucks_pct, null, sl_fossilFuelTrucks_pct );
-f_setElectricTrucks( sl_electricTrucks_pct.getValue() );]]></ActionCode>
+f_setElectricTrucks( sl_electricTrucks_pct.getValue(), sl_electricTrucks_pct, sl_fossilFuelTrucks_pct );]]></ActionCode>
 					</BasicProperties>
 					<ExtendedProperties>
 						<DefaultValueCode><![CDATA[0]]></DefaultValueCode>
@@ -22931,14 +23370,15 @@ f_setElectricTrucks( sl_electricTrucks_pct.getValue() );]]></ActionCode>
 					<BasicProperties Width="100" Height="30">
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
-						<ActionCode><![CDATA[f_setDemandReduction( sl_mobilityDemandReduction_pct.getValue() );]]></ActionCode>
+						<ActionCode><![CDATA[f_setDemandReduction( sl_mobilityDemandReduction_pct.getValue() );
+]]></ActionCode>
 					</BasicProperties>
 					<ExtendedProperties>
 						<DefaultValueCode><![CDATA[0]]></DefaultValueCode>
 						<Orientation>HORIZONTAL</Orientation>
 						<MinValue><![CDATA[0]]></MinValue>
-						<MaxValue><![CDATA[100]]></MaxValue>
-						<Step><![CDATA[1]]></Step>
+						<MaxValue><![CDATA[50]]></MaxValue>
+						<Step><![CDATA[5]]></Step>
 						<LinkTo>false</LinkTo>
 					</ExtendedProperties>
 				</Control>
@@ -23045,7 +23485,7 @@ f_setElectricTrucks( sl_electricTrucks_pct.getValue() );]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[f_setVehicleSliders( 2, sl_electricTrucks_pct, null, sl_fossilFuelTrucks_pct );
-f_setElectricTrucks(sl_electricTrucks_pct.getValue());]]></ActionCode>
+f_setElectricTrucks(sl_electricTrucks_pct.getValue(), sl_electricTrucks_pct, sl_fossilFuelTrucks_pct );]]></ActionCode>
 					</BasicProperties>
 					<ExtendedProperties>
 						<DefaultValueCode><![CDATA[0]]></DefaultValueCode>
@@ -23134,7 +23574,7 @@ f_setElectricTrucks(sl_electricTrucks_pct.getValue());]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[sl_fossilFuelCars_pct.setValue(100 - sl_electricCars_pct.getIntValue(), false);
-f_setElectricCars( sl_electricCars_pct.getValue() );]]></ActionCode>
+f_setElectricCars( sl_electricCars_pct.getValue(), sl_electricCars_pct, sl_fossilFuelCars_pct );]]></ActionCode>
 					</BasicProperties>
 					<ExtendedProperties>
 						<DefaultValueCode><![CDATA[0]]></DefaultValueCode>
@@ -23223,7 +23663,7 @@ f_setElectricCars( sl_electricCars_pct.getValue() );]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[sl_electricVans_pct.setValue(100 - sl_fossilFuelVans_pct.getIntValue(), false);
-f_setElectricVans( sl_electricVans_pct.getValue() );]]></ActionCode>
+f_setElectricVans( sl_electricVans_pct.getValue(), sl_electricVans_pct, sl_fossilFuelVans_pct );]]></ActionCode>
 					</BasicProperties>
 					<ExtendedProperties>
 						<DefaultValueCode><![CDATA[0]]></DefaultValueCode>
@@ -23291,7 +23731,7 @@ f_setElectricVans( sl_electricVans_pct.getValue() );]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[sl_fossilFuelVans_pct.setValue(100 - sl_electricVans_pct.getIntValue(), false);
-f_setElectricVans( sl_electricVans_pct.getValue() );]]></ActionCode>
+f_setElectricVans( sl_electricVans_pct.getValue(), sl_electricVans_pct, sl_fossilFuelVans_pct );]]></ActionCode>
 					</BasicProperties>
 					<ExtendedProperties>
 						<DefaultValueCode><![CDATA[0]]></DefaultValueCode>
@@ -23723,43 +24163,63 @@ public ShapeSlider getWindSlider(){
 						<Name><![CDATA[PV_pct]]></Name>
 						<Type><![CDATA[double]]></Type>
 					</Parameter>
-					<Body><![CDATA[double PVsystems = count(zero_Interface.energyModel.UtilityConnections, x->x.v_hasPV == true);
+					<Parameter>
+						<Name><![CDATA[usedSlider]]></Name>
+						<Type><![CDATA[ShapeSlider]]></Type>
+					</Parameter>
+					<Body><![CDATA[double PVsystems = count(zero_Interface.energyModel.UtilityConnections, x->x.v_hasPV == true && x.v_isActive);
+double totalActiveUtilityConnections = count(zero_Interface.energyModel.UtilityConnections, gc -> gc.v_isActive);
 
-if( PV_pct/100.0 < PVsystems/zero_Interface.energyModel.UtilityConnections.size() ){
-	while ( PV_pct/100.0*zero_Interface.energyModel.UtilityConnections.size() < PVsystems) { // remove excess PV systems
+if( PV_pct/100.0 < PVsystems/totalActiveUtilityConnections ){
+	while ( PV_pct/100.0*totalActiveUtilityConnections < PVsystems) { // remove excess PV systems
 		GridConnection gc = findFirst(zero_Interface.c_orderedPVSystems, x->x.v_hasPV==true);
 		
-		
-		// update UI company
-		if(zero_Interface.c_companyUIs.size() > 0){
-		UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
-		//if (companyUI.c_ownedGridConnections.get(0) == gc) { // should also check the setting of selected GC
-			if (companyUI.v_minPVSlider != 0) {
-				traceln("Removed already existing PV system");
+		if(gc != null){
+			// update UI company
+			if (zero_Interface.c_companyUIs.size()>0){
+				UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
+				if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == gc) { // should also check the setting of selected GC
+					if (companyUI.v_minPVSlider != 0) {
+						traceln("Removed already existing PV system");
+					}
+					else {
+						companyUI.sl_rooftopPVCompany.setValue(0, false);
+						companyUI.v_defaultPVSlider = 0;
+					}
+				}
 			}
-			else {
-				companyUI.sl_rooftopPVCompany.setValue(0, false);
-				companyUI.t_rooftopSolarCompany.setText("0 kW");
+			
+			J_EA pvAsset = findFirst(gc.c_productionAssets, p -> p.energyAssetType == OL_EnergyAssetType.PHOTOVOLTAIC );
+			//traceln("Found PV system: " + pvAsset);
+			if (pvAsset!=null) {
+				pvAsset.removeEnergyAsset();
+				zero_Interface.c_orderedPVSystems.remove(gc);
+				zero_Interface.c_orderedPVSystems.add(0, gc);
+				//traceln("Removing PV from GridConnection:" + h.p_gridConnectionID);
 			}
-		}
-		//}
-		
-		J_EA pvAsset = findFirst(gc.c_productionAssets, p -> p.energyAssetType == OL_EnergyAssetType.PHOTOVOLTAIC );
-		//traceln("Found PV system: " + pvAsset);
-		if (pvAsset!=null) {
-			pvAsset.removeEnergyAsset();
-			zero_Interface.c_orderedPVSystems.remove(gc);
-			zero_Interface.c_orderedPVSystems.add(0,gc);
-			//traceln("Removing PV from GridConnection:" + h.p_gridConnectionID);
-		}
-		
+			else{
+				gc.v_hasPV = false;
+			}
+			//Color the buildings when in solar color mode
+			if(zero_Interface.rb_buildingColors.getValue() == 2){
+				for(GIS_Object building : gc.c_connectedGISObjects){
+					zero_Interface.f_styleAreas(building);
+				}
+			}
+			
 		// Recalculating the amount of PV Systems instead of just decreasing by one to account for possibility of having multiple PV Assets
-		PVsystems=count(zero_Interface.energyModel.UtilityConnections, x->x.v_hasPV == true);		
+		PVsystems--; //=count(zero_Interface.energyModel.UtilityConnections, x->x.v_hasPV == true);		
+		}
+		else{//No pv systems to adjust, set slider to minimum and do nothing else
+			int min_pct_pvSystems = roundToInt(100.0 * ((double)count(zero_Interface.energyModel.UtilityConnections, x->x.v_hasPV == true && x.v_isActive) / totalActiveUtilityConnections));
+			usedSlider.setValue(min_pct_pvSystems, false);
+			return;
+		}
 	}
- 
 }
 else {
-	while ( PV_pct/100.0 > PVsystems/zero_Interface.energyModel.UtilityConnections.size()) {
+	while ( PV_pct/100.0 > PVsystems/totalActiveUtilityConnections) {
+
 		GridConnection gc = findFirst(zero_Interface.c_orderedPVSystems, x->x.v_hasPV==false);
 		if (gc == null){
 			traceln("No gridconnection without PV panels found! Current PVsystems count: %s", PVsystems);
@@ -23769,7 +24229,7 @@ else {
 			OL_EnergyAssetType assetType = OL_EnergyAssetType.PHOTOVOLTAIC;
 			String assetName = "Rooftop PV";
 
-			double roofAreaForPV_m2 = 0.75 * gc.p_roofSurfaceArea_m2;						
+			double roofAreaForPV_m2 = 0.25 * gc.p_roofSurfaceArea_m2; // Should not be higher than 0.5!						
 			double capacityElectricity_kW = max(0.1, roofAreaForPV_m2*zero_Interface.energyModel.avgc_data.p_avgPVPower_kWpm2);
 			double capacityHeat_kW = 0.0;
 			double yearlyProductionHydrogen_kWh = 0.0;
@@ -23777,21 +24237,28 @@ else {
 			double outputTemperature_degC = 0.0;
 			
 			J_EAProduction productionAsset = new J_EAProduction ( gc, assetType, assetName, capacityElectricity_kW, capacityHeat_kW, yearlyProductionMethane_kWh, yearlyProductionHydrogen_kWh, zero_Interface.energyModel.p_timeStep_h, outputTemperature_degC, zero_Interface.energyModel.pp_solarPVproduction );
-
+			
+			//Add GC to top of the orderd pv systems so it will be found first when removing.
 			zero_Interface.c_orderedPVSystems.remove(gc);
 			zero_Interface.c_orderedPVSystems.add(0, gc);
 		
 			PVsystems++;
 			//traceln("Added PV to GridConnection: " + h.p_gridConnectionID);
-		
 			
 			// update UI company
-			if(zero_Interface.c_companyUIs.size() > 0){
-			UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
-			//if (companyUI.c_ownedGridConnections.get(0) == gc) { // should also check the setting of selected GC
-				companyUI.sl_rooftopPVCompany.setValue(roundToInt(capacityElectricity_kW), false);
-				companyUI.t_rooftopSolarCompany.setText(roundToInt(capacityElectricity_kW) + " kW");
-			//}
+			if (zero_Interface.c_companyUIs.size()>0){
+				UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
+				if (companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == gc) { // should also check the setting of selected GC
+					companyUI.sl_rooftopPVCompany.setValue(roundToInt(capacityElectricity_kW), false);
+					companyUI.v_defaultPVSlider = roundToInt(capacityElectricity_kW);
+				}
+			}
+			
+			//Color the buildings when in solar color mode
+			if(zero_Interface.rb_buildingColors.getValue() == 2){
+				for(GIS_Object building : gc.c_connectedGISObjects){
+					zero_Interface.f_styleAreas(building);
+				}
 			}
 		}
 	}
@@ -24086,12 +24553,26 @@ for (J_EA j_ea : zero_Interface.energyModel.f_getEnergyAssets()) {
 	if (j_ea instanceof J_EAConsumption) {
 		if (j_ea.energyAssetType == OL_EnergyAssetType.ELECTRICITY_DEMAND) {
 			((J_EAConsumption)j_ea).setConsumptionScaling_fr(consumptionScaling_fr);
+			
+			if (zero_Interface.c_companyUIs.size()>0){
+				UI_company companyUI = zero_Interface.c_companyUIs.get(((GridConnection)j_ea.getParentAgent()).p_owner.p_connectionOwnerIndexNr);
+				if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == j_ea.getParentAgent()) { // should also check the setting of selected GC
+					companyUI.sl_electricityDemandCompanyReduction.setValue(newElectricityDemandReduction_pct, false);
+				}
+			}
 		}
 	}
 	if (j_ea instanceof J_EAProfile) {
 		if (((J_EAProfile) j_ea).energyCarrierConsumed == OL_EnergyCarrierType.ELECTRICITY) {
 			((J_EAProfile) j_ea).resetEnergyProfile();
 			((J_EAProfile) j_ea).scaleEnergyProfile(consumptionScaling_fr);
+			
+			if (zero_Interface.c_companyUIs.size()>0){
+				UI_company companyUI = zero_Interface.c_companyUIs.get(((GridConnection)j_ea.getParentAgent()).p_owner.p_connectionOwnerIndexNr);
+				if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == j_ea.getParentAgent()) { // should also check the setting of selected GC
+					companyUI.sl_electricityDemandCompanyReduction.setValue(newElectricityDemandReduction_pct, false);
+				}
+			}
 		}
 	}
 }
@@ -24989,7 +25470,7 @@ f_setPublicChargingStations(sliderValue);]]></ActionCode>
 						<Orientation>HORIZONTAL</Orientation>
 						<MinValue><![CDATA[0]]></MinValue>
 						<MaxValue><![CDATA[50]]></MaxValue>
-						<Step><![CDATA[1]]></Step>
+						<Step><![CDATA[5]]></Step>
 						<LinkTo>false</LinkTo>
 					</ExtendedProperties>
 				</Control>
@@ -25070,7 +25551,7 @@ f_setPublicChargingStations(sliderValue);]]></ActionCode>
 					<BasicProperties Width="100" Height="30">
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
-						<ActionCode><![CDATA[f_setPVSystemCompanies(sl_rooftopPVCompanies_pct.getValue());]]></ActionCode>
+						<ActionCode><![CDATA[f_setPVSystemCompanies(sl_rooftopPVCompanies_pct.getValue(), sl_rooftopPVCompanies_pct);]]></ActionCode>
 					</BasicProperties>
 					<ExtendedProperties>
 						<DefaultValueCode><![CDATA[0]]></DefaultValueCode>
@@ -26143,7 +26624,7 @@ f_setPublicChargingStationsScale(sliderValue);]]></ActionCode>
 						<Orientation>HORIZONTAL</Orientation>
 						<MinValue><![CDATA[0]]></MinValue>
 						<MaxValue><![CDATA[50]]></MaxValue>
-						<Step><![CDATA[1]]></Step>
+						<Step><![CDATA[5]]></Step>
 						<LinkTo>false</LinkTo>
 					</ExtendedProperties>
 				</Control>
@@ -26224,7 +26705,7 @@ f_setPublicChargingStationsScale(sliderValue);]]></ActionCode>
 					<BasicProperties Width="100" Height="30">
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
-						<ActionCode><![CDATA[f_setPVSystemCompanies(sl_rooftopPVCompanies_pct_Businesspark.getValue());]]></ActionCode>
+						<ActionCode><![CDATA[f_setPVSystemCompanies(sl_rooftopPVCompanies_pct_Businesspark.getValue(), sl_rooftopPVCompanies_pct_Businesspark);]]></ActionCode>
 					</BasicProperties>
 					<ExtendedProperties>
 						<DefaultValueCode><![CDATA[0]]></DefaultValueCode>
@@ -26608,113 +27089,153 @@ public ShapeSlider getSliderHeatDemandSlidersCompaniesElectricHeatPumpCompanies_
 						</InitialValue>
 					</Properties>
 				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1729262524509</Id>
+					<Name><![CDATA[v_totalNumberOfGhostHeatingSystems_ElectricHeatpumps]]></Name>
+					<X>60</X><Y>1020</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[int]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[0]]></Code>
+						</InitialValue>
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1729262555712</Id>
+					<Name><![CDATA[v_totalNumberOfGhostHeatingSystems_HybridHeatpumps]]></Name>
+					<X>60</X><Y>1040</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[int]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[0]]></Code>
+						</InitialValue>
+					</Properties>
+				</Variable>
 			</Variables>
 			<Functions>
 				<Function AccessType="protected" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
-					<ReturnType><![CDATA[double]]></ReturnType>
+					<ReturnType><![CDATA[int]]></ReturnType>
 					<Id>1722256102007</Id>
 					<Name><![CDATA[f_setHeatingSystemsCompanies]]></Name>
 					<Description><![CDATA[Function that adds or removes heatpumps to utility connections. Takes a percentage as a parameter and runs untill that percentage of all the utility connections has a heatpump. If a new heatpump is created it determines its heat demand on a heat_demand consumption asset if it exists, else it looks for a heat profile asset. The function also updates the radio button in the company UI.]]></Description>
-					<X>110</X><Y>790</Y>
+					<X>70</X><Y>790</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Parameter>
-						<Name><![CDATA[targetHeatPump_pct]]></Name>
-						<Type><![CDATA[double]]></Type>
+						<Name><![CDATA[sliderGasburner]]></Name>
+						<Type><![CDATA[ShapeSlider]]></Type>
 					</Parameter>
-					<Body><![CDATA[//Setting Heating systems
-int nbHeatPumps = count(zero_Interface.energyModel.UtilityConnections, gc->gc.p_primaryHeatingAsset instanceof J_EAConversionHeatPump);
-int nbConnectionsWithHeat = count(zero_Interface.energyModel.UtilityConnections, gc -> gc.p_primaryHeatingAsset != null);
-int targetHeatPumpAmount = roundToInt(targetHeatPump_pct/100.0* nbConnectionsWithHeat);
+					<Parameter>
+						<Name><![CDATA[sliderHeatpump]]></Name>
+						<Type><![CDATA[ShapeSlider]]></Type>
+					</Parameter>
+					<Body><![CDATA[double targetHeatPump_pct = sliderHeatpump.getValue();
 
-// TODO: Bugfix needed. Not all companies have a heat demand, if the heat demand is zero. Then it should not try to mess with their heating asset or it might create an asset with capacity 0.
-/*
-java.lang.RuntimeException: Exception: J_EAGasBurner with capacityHeat_kW = 0, invalid state! 
-Energy Asset: AssetType = GAS_BURNER parentAgent = root.energyModel.UtilityConnections[117],
-Energy consumed = 0.0 capacityElectric_kW = 0.0 capacityHeat_kW = 0.0 eta_r = 0.99 
-outputTemperature_degC = 90.0 energyUsed_kWh (losses) = 0.0 heatProducted_kWh = 0.0
-*/
-// Also results in NaN values in the electricity flows, probably division by zero?
-// Why doesn't it skip these companies already? 0 heat demand should probably mean they did not get an asset in the loader?
-// Because, UtilityConnection 117 was ROVA! It indeed has 0 heat demand, but does have an asset.
 
-if( targetHeatPumpAmount < nbHeatPumps){
-	while ( targetHeatPumpAmount < nbHeatPumps) { // remove excess heatpumps, replace with gasburners.
-		//traceln("While loop for removing heatpumps");
-		GridConnection gc = findFirst(zero_Interface.c_orderedHeatingSystemsCompanies, x->x.p_primaryHeatingAsset instanceof J_EAConversionHeatPump);
-		if (gc!=null) {
-		
-			// update UI company
-			UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
-			//if (companyUI.c_ownedGridConnections.get(0) == gc) { // should also check the setting of selected GC
-				if (companyUI.c_scenarioSettings_Current.get(0).getCurrentHeatingType() == OL_GridConnectionHeatingType.ELECTRIC_HEATPUMP) {
-					traceln("Removed already existing Heatpump");
+//Set the sliders if companyUI is present using the companyUI functions, if not: do it the normal way
+if(zero_Interface.c_companyUIs.size()>0){
+ 	f_setHeatingSystemsWithCompanyUI(targetHeatPump_pct, sliderGasburner, sliderHeatpump);
+}
+else{
+	//Setting Heating systems
+	int nbHeatPumps = count(zero_Interface.energyModel.UtilityConnections, gc -> gc.p_primaryHeatingAsset instanceof J_EAConversionHeatPump);
+	int nbConnectionsWithHeat = count(zero_Interface.energyModel.UtilityConnections, gc -> gc.p_primaryHeatingAsset != null);
+	int targetHeatPumpAmount = roundToInt(targetHeatPump_pct/100.0* nbConnectionsWithHeat);
+
+	if( targetHeatPumpAmount < nbHeatPumps){
+		while ( targetHeatPumpAmount < nbHeatPumps) { // remove excess heatpumps, replace with gasburners.
+			//traceln("While loop for removing heatpumps");
+			GridConnection gc = findFirst(zero_Interface.c_orderedHeatingSystemsCompanies, x->x.p_primaryHeatingAsset instanceof J_EAConversionHeatPump);
+			if (gc!=null) {
+				
+				/*
+				// update UI company
+				if (zero_Interface.c_companyUIs.size()>0){
+					UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
+					if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == gc) { // should also check the setting of selected GC
+						if (companyUI.c_scenarioSettings_Current.get(0).getCurrentHeatingType() == OL_GridConnectionHeatingType.ELECTRIC_HEATPUMP) {
+							traceln("Removed already existing Heatpump");
+						}
+						//else {
+							companyUI.rb_heatingTypePrivateUI.setValue(0, false);
+						//}
+					}
 				}
-				//else {
-					companyUI.rb_heatingTypePrivateUI.setValue(0, false);
-				//}
-			//}
-			
-			J_EA heatPump = gc.p_primaryHeatingAsset;
-			//traceln("Found heatpump: " + heatPump);		
-			heatPump.removeEnergyAsset();
-			zero_Interface.c_orderedHeatingSystemsCompanies.remove(gc);
-			zero_Interface.c_orderedHeatingSystemsCompanies.add(0, gc);
-			//traceln("Removing heatpump from GridConnection:" + gc.p_gridConnectionID);
-			J_EAConsumption heatDemandAsset = findFirst(gc.c_consumptionAssets, j_ea->j_ea.energyAssetType == OL_EnergyAssetType.HEAT_DEMAND);
-			J_EAConversionGasBurner gasBurner;
-			if (heatDemandAsset != null) {
-				gasBurner = new J_EAConversionGasBurner(gc, OL_EnergyAssetType.GAS_BURNER, heatDemandAsset.yearlyDemandHeat_kWh/8760*10, 0.99, zero_Interface.energyModel.p_timeStep_h, 90);
-			} else {
-				J_EAProfile heatDemandProfile = (J_EAProfile)findFirst(gc.c_profileAssets, x->x instanceof J_EAProfile && x.energyCarrierConsumed == OL_EnergyCarrierType.HEAT);
-				double peakHeatDemand_kW = Arrays.stream(heatDemandProfile.a_energyProfile_kWh).max().orElseThrow(() -> new RuntimeException());
-				gasBurner = new J_EAConversionGasBurner(gc, OL_EnergyAssetType.GAS_BURNER, peakHeatDemand_kW, 0.99, zero_Interface.energyModel.p_timeStep_h, 90);
-			}			
-		}
-		
-		nbHeatPumps--;
-		//traceln("Number of heatpumps: " + nbHeatPumps);
-	}
- 
-} else { 
-	while ( targetHeatPumpAmount > nbHeatPumps) { // remove gasburners, add heatpumps.
-		//traceln("While loop for adding heatpumps");
-		GridConnection gc = findFirst(zero_Interface.c_orderedHeatingSystemsCompanies, x->x.p_primaryHeatingAsset instanceof J_EAConversionGasBurner);
-
-		if (gc!=null) {
-		
-			// update UI company
-			UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
-			//if (companyUI.c_ownedGridConnections.get(0) == gc) { // should also check the setting of selected GC
-				companyUI.rb_heatingTypePrivateUI.setValue(2, false);
-			//}
-			
-			J_EA gasBurner = gc.p_primaryHeatingAsset;
-			gasBurner.removeEnergyAsset();
-			
-			J_EAConversionHeatPump heatPump;
-			J_EAConsumption heatDemandAsset = findFirst(gc.c_consumptionAssets, j_ea->j_ea.energyAssetType == OL_EnergyAssetType.HEAT_DEMAND);
-			if (heatDemandAsset != null) {
-				heatPump = new J_EAConversionHeatPump(gc, zero_Interface.energyModel.p_timeStep_h, heatDemandAsset.yearlyDemandHeat_kWh/8760*10 / 3, 0.5, zero_Interface.energyModel.v_currentAmbientTemperature_degC, 60, "AIR", 0, 1);
-			} else {
-				J_EAProfile heatDemandProfile = (J_EAProfile)findFirst(gc.c_profileAssets, x->x instanceof J_EAProfile && x.energyCarrierConsumed == OL_EnergyCarrierType.HEAT);
-				double peakHeatDemand_kW = Arrays.stream(heatDemandProfile.a_energyProfile_kWh).max().orElseThrow(() -> new RuntimeException());
-				heatPump = new J_EAConversionHeatPump(gc, zero_Interface.energyModel.p_timeStep_h, peakHeatDemand_kW / 3, 0.5, zero_Interface.energyModel.v_currentAmbientTemperature_degC, 60, "AIR", 0, 1);
+				*/
+				
+				J_EA heatPump = gc.p_primaryHeatingAsset;
+				//traceln("Found heatpump: " + heatPump);		
+				heatPump.removeEnergyAsset();
+				zero_Interface.c_orderedHeatingSystemsCompanies.remove(gc);
+				zero_Interface.c_orderedHeatingSystemsCompanies.add(0, gc);
+				//traceln("Removing heatpump from GridConnection:" + gc.p_gridConnectionID);
+				J_EAConsumption heatDemandAsset = findFirst(gc.c_consumptionAssets, j_ea->j_ea.energyAssetType == OL_EnergyAssetType.HEAT_DEMAND);
+				J_EAConversionGasBurner gasBurner;
+				if (heatDemandAsset != null) {
+					gasBurner = new J_EAConversionGasBurner(gc, OL_EnergyAssetType.GAS_BURNER, heatDemandAsset.yearlyDemandHeat_kWh/8760*10, 0.99, zero_Interface.energyModel.p_timeStep_h, 90);
+				} else {
+					J_EAProfile heatDemandProfile = (J_EAProfile)findFirst(gc.c_profileAssets, x->x instanceof J_EAProfile && x.energyCarrierConsumed == OL_EnergyCarrierType.HEAT);
+					double peakHeatDemand_kW = Arrays.stream(heatDemandProfile.a_energyProfile_kWh).max().orElseThrow(() -> new RuntimeException());
+					gasBurner = new J_EAConversionGasBurner(gc, OL_EnergyAssetType.GAS_BURNER, peakHeatDemand_kW, 0.99, zero_Interface.energyModel.p_timeStep_h, 90);
+				}			
 			}
-			zero_Interface.c_orderedHeatingSystemsCompanies.remove(gc);
-			zero_Interface.c_orderedHeatingSystemsCompanies.add(0, gc);		 
-			//traceln("Added heatpump to GridConnection: " + gc.p_gridConnectionID);
-		} else {
-			traceln("No more gasburners to replace!");
-			break;
+			
+			nbHeatPumps--;
+			//traceln("Number of heatpumps: " + nbHeatPumps);
+		}
+	 
+	} else { 
+		while ( targetHeatPumpAmount > nbHeatPumps) { // remove gasburners, add heatpumps.
+			//traceln("While loop for adding heatpumps");
+			GridConnection gc = findFirst(zero_Interface.c_orderedHeatingSystemsCompanies, x->x.p_primaryHeatingAsset instanceof J_EAConversionGasBurner);
+	
+			if (gc!=null) {
+				
+				/*
+				// update UI company
+				if (zero_Interface.c_companyUIs.size()>0){
+					UI_company companyUI = zero_Interface.c_companyUIs.get(gc.p_owner.p_connectionOwnerIndexNr);
+					if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == gc) { // should also check the setting of selected GC
+						companyUI.rb_heatingTypePrivateUI.setValue(2, false);
+					}
+				}
+				*/
+				J_EA gasBurner = gc.p_primaryHeatingAsset;
+				gasBurner.removeEnergyAsset();
+				
+				J_EAConversionHeatPump heatPump;
+				J_EAConsumption heatDemandAsset = findFirst(gc.c_consumptionAssets, j_ea->j_ea.energyAssetType == OL_EnergyAssetType.HEAT_DEMAND);
+				if (heatDemandAsset != null) {
+					heatPump = new J_EAConversionHeatPump(gc, zero_Interface.energyModel.p_timeStep_h, heatDemandAsset.yearlyDemandHeat_kWh/8760*10 / 3, 0.5, zero_Interface.energyModel.v_currentAmbientTemperature_degC, 60, "AIR", 0, 1);
+				} else {
+					J_EAProfile heatDemandProfile = (J_EAProfile)findFirst(gc.c_profileAssets, x->x instanceof J_EAProfile && x.energyCarrierConsumed == OL_EnergyCarrierType.HEAT);
+					double peakHeatDemand_kW = Arrays.stream(heatDemandProfile.a_energyProfile_kWh).max().orElseThrow(() -> new RuntimeException());
+					heatPump = new J_EAConversionHeatPump(gc, zero_Interface.energyModel.p_timeStep_h, peakHeatDemand_kW / 3, 0.5, zero_Interface.energyModel.v_currentAmbientTemperature_degC, 60, "AIR", 0, 1);
+				}
+				zero_Interface.c_orderedHeatingSystemsCompanies.remove(gc);
+				zero_Interface.c_orderedHeatingSystemsCompanies.add(0, gc);		 
+				//traceln("Added heatpump to GridConnection: " + gc.p_gridConnectionID);
+			} else {
+				traceln("No more gasburners to replace!");
+				break;
+			}	
+			
+			nbHeatPumps++;
 		}	
-		
-		nbHeatPumps++;
-	}	
-}]]></Body>
+	}
+}
+]]></Body>
 				</Function>
 				<Function AccessType="protected" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
@@ -26722,7 +27243,7 @@ if( targetHeatPumpAmount < nbHeatPumps){
 					<Id>1722256221655</Id>
 					<Name><![CDATA[f_setHeatingSystemsHouseholds]]></Name>
 					<Description><![CDATA[Function that adds or removes heatpumps to houses. Takes a percentage as a parameter and runs untill that percentage of all the houses has a heatpump. If a new heatpump is created it determines its heat demand on a heat_demand consumption asset if it exists, else it looks for a heat profile asset.]]></Description>
-					<X>110</X><Y>810</Y>
+					<X>70</X><Y>830</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -26798,7 +27319,7 @@ else {
 					<Id>1722256269495</Id>
 					<Name><![CDATA[f_setHeatingSliders]]></Name>
 					<Description><![CDATA[Function that calculates all the values of the other sliders and sets them without calling an action. Takes as parameters the index of the slider which should not be touched as well as all the sliders. HybridHeatPump and DistrictHeating sliders are optional and an argument of null can be passed. ]]></Description>
-					<X>110</X><Y>770</Y>
+					<X>70</X><Y>770</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -26883,12 +27404,25 @@ for (J_EA j_ea : zero_Interface.energyModel.f_getEnergyAssets()){
 		if (j_ea instanceof J_EAConsumption) {
 			if (j_ea.energyAssetType == OL_EnergyAssetType.HEAT_DEMAND) {
 				((J_EAConsumption)j_ea).setConsumptionScaling_fr(consumptionScaling_fr);
+				
+				if (zero_Interface.c_companyUIs.size()>0){
+					UI_company companyUI = zero_Interface.c_companyUIs.get(((GridConnection)parentGC).p_owner.p_connectionOwnerIndexNr);
+					if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == parentGC) { // should also check the setting of selected GC
+						companyUI.sl_heatDemandCompanyReduction.setValue(newHeatDemandReduction_pct, false);
+					}
+				}	
 			}
 		}
 		if (j_ea instanceof J_EAProfile) {
 			if (((J_EAProfile) j_ea).energyCarrierConsumed == OL_EnergyCarrierType.HEAT) {
 				((J_EAProfile) j_ea).resetEnergyProfile();
 				((J_EAProfile) j_ea).scaleEnergyProfile(consumptionScaling_fr);
+				if (zero_Interface.c_companyUIs.size()>0){
+					UI_company companyUI = zero_Interface.c_companyUIs.get(((GridConnection)parentGC).p_owner.p_connectionOwnerIndexNr);
+					if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == parentGC) { // should also check the setting of selected GC
+						companyUI.sl_heatDemandCompanyReduction.setValue(newHeatDemandReduction_pct, false);
+					}
+				}
 			}
 		}
 	}
@@ -26938,6 +27472,134 @@ for (J_EA j_ea : zero_Interface.energyModel.f_getEnergyAssets()){
 v_heatDemandReductionHouses_pct = newHeatDemandReduction_pct;
  
 zero_Interface.f_resetSettings();]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[int]]></ReturnType>
+					<Id>1729259449060</Id>
+					<Name><![CDATA[f_setHeatingSystemsWithCompanyUI]]></Name>
+					<X>90</X><Y>810</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[targetHeatPump_pct]]></Name>
+						<Type><![CDATA[double]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[sliderGasburner]]></Name>
+						<Type><![CDATA[ShapeSlider]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[sliderHeatpump]]></Name>
+						<Type><![CDATA[ShapeSlider]]></Type>
+					</Parameter>
+					<Body><![CDATA[//Setting Heating systems
+int nbHeatPumps = count(zero_Interface.energyModel.UtilityConnections, gc -> gc.p_primaryHeatingAsset instanceof J_EAConversionHeatPump && gc.v_isActive) + v_totalNumberOfGhostHeatingSystems_ElectricHeatpumps + v_totalNumberOfGhostHeatingSystems_HybridHeatpumps;// && gc.p_secondaryHeatingAsset == null );
+int nbConnectionsWithHeat = count(zero_Interface.energyModel.UtilityConnections, gc -> gc.p_primaryHeatingAsset != null && gc.v_isActive) + v_totalNumberOfGhostHeatingSystems_ElectricHeatpumps + v_totalNumberOfGhostHeatingSystems_HybridHeatpumps;
+int targetHeatPumpAmount = roundToInt(targetHeatPump_pct/100.0* nbConnectionsWithHeat);
+
+if( targetHeatPumpAmount < nbHeatPumps){
+	while ( targetHeatPumpAmount < nbHeatPumps){ // remove excess heatpumps of companies that didnt start with a heatpump, replace with gasburners.
+		
+		GridConnection GC = findFirst(zero_Interface.c_orderedHeatingSystemsCompanies, gc -> gc.p_primaryHeatingAsset instanceof J_EAConversionHeatPump);
+		
+		if (GC!=null) {
+			UI_company companyUI = zero_Interface.c_companyUIs.get(GC.p_owner.p_connectionOwnerIndexNr);
+			
+			companyUI.b_runningMainInterfaceSlider = true;
+			if(companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) != GC){
+				int selectedGC = 0;
+				if(companyUI.v_currentSelectedGCnr != 0){
+					companyUI.GCnr_selection.setValue(selectedGC, true); 
+				}
+				while (companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) != GC){ //Check if selected
+					companyUI.GCnr_selection.setValue(selectedGC++, true);
+				}
+			}
+			
+			companyUI.rb_heatingTypePrivateUI.setValue(0, true);
+			companyUI.rb_scenariosPrivateUI.setValue(2, false);
+			companyUI.b_runningMainInterfaceSlider = false;
+
+			//Reorder c_orderedHeatingSystems
+			zero_Interface.c_orderedHeatingSystemsCompanies.remove(GC);
+			zero_Interface.c_orderedHeatingSystemsCompanies.add(0, GC);
+			
+			nbHeatPumps--;
+		}
+		else{//No more heating assets to adjust: this is the minimum: set slider to minimum and do nothing else
+			int min_nbOfHeatpumps = count(zero_Interface.energyModel.UtilityConnections, gc -> gc.v_isActive && gc.p_primaryHeatingAsset instanceof J_EAConversionHeatPump) + v_totalNumberOfGhostHeatingSystems_ElectricHeatpumps + v_totalNumberOfGhostHeatingSystems_HybridHeatpumps;
+			int min_pct_ElectricHeatpumpSlider = (int) ((float) min_nbOfHeatpumps / nbConnectionsWithHeat * 100.0);
+			sliderHeatpump.setValue(min_pct_ElectricHeatpumpSlider, false);
+			sliderGasburner.setValue(100-min_pct_ElectricHeatpumpSlider, false);
+			return;
+		}
+	}
+} else { 
+	while ( targetHeatPumpAmount > nbHeatPumps) { // remove gasburners, add heatpumps.
+			
+		GridConnection GC = findFirst(zero_Interface.c_orderedHeatingSystemsCompanies, gc -> gc.p_primaryHeatingAsset instanceof J_EAConversionGasBurner);
+		if (GC!=null) {
+			UI_company companyUI = zero_Interface.c_companyUIs.get(GC.p_owner.p_connectionOwnerIndexNr);
+			companyUI.b_runningMainInterfaceSlider = true;
+			if(companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) != GC){
+				int selectedGC = 0;
+				if(companyUI.v_currentSelectedGCnr != 0){
+					companyUI.GCnr_selection.setValue(selectedGC, true); 
+				}
+				while (companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) != GC){ //Check if selected
+					companyUI.GCnr_selection.setValue(selectedGC++, true);
+				}
+			}
+			companyUI.rb_heatingTypePrivateUI.setValue(2, true);
+			companyUI.rb_scenariosPrivateUI.setValue(2, false);
+			companyUI.b_runningMainInterfaceSlider = false;
+			
+			//Reorder c_orderedHeatingSystems
+			zero_Interface.c_orderedHeatingSystemsCompanies.remove(GC);
+			zero_Interface.c_orderedHeatingSystemsCompanies.add(0, GC);
+			
+			nbHeatPumps++;
+		}
+		else{//No more gas burner assets to adjust: this is the minimum: set slider to minimum and do nothing else
+			int min_nbOfHeatpumps = count(zero_Interface.energyModel.UtilityConnections, gc -> gc.v_isActive && gc.p_primaryHeatingAsset instanceof J_EAConversionHeatPump) + v_totalNumberOfGhostHeatingSystems_ElectricHeatpumps + v_totalNumberOfGhostHeatingSystems_HybridHeatpumps;
+			int min_pct_ElectricHeatpumpSlider = (int) ((float) min_nbOfHeatpumps / nbConnectionsWithHeat * 100.0);
+			sliderHeatpump.setValue(min_pct_ElectricHeatpumpSlider, false);
+			sliderGasburner.setValue(100-min_pct_ElectricHeatpumpSlider, false);
+			return;
+		}
+	}	
+}]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1729262524479</Id>
+					<Name><![CDATA[f_getNumberOfGhostHeatingSystems]]></Name>
+					<X>40</X><Y>1000</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[v_totalNumberOfGhostHeatingSystems_ElectricHeatpumps = 0;
+v_totalNumberOfGhostHeatingSystems_HybridHeatpumps = 0;
+
+for (UI_company companyUI : zero_Interface.c_companyUIs ){
+	
+	for(int i = 0; i < companyUI.c_ownedGridConnections.size(); i++){
+		if(companyUI.c_ownedGridConnections.get(i).v_hasQuarterHourlyValues && companyUI.c_ownedGridConnections.get(i).v_isActive){
+			if (companyUI.c_scenarioSettings_Current.get(i).getCurrentHeatingType() == OL_GridConnectionHeatingType.ELECTRIC_HEATPUMP){
+				v_totalNumberOfGhostHeatingSystems_ElectricHeatpumps++;
+			}
+			if (companyUI.c_scenarioSettings_Current.get(i).getCurrentHeatingType() == OL_GridConnectionHeatingType.HYBRID_HEATPUMP){
+				v_totalNumberOfGhostHeatingSystems_HybridHeatpumps++;
+			}
+		}
+	}
+}
+]]></Body>
 				</Function>
 			</Functions>
 			<AgentLinks>
@@ -27477,7 +28139,7 @@ f_setHeatingSystemsHouseholds( sl_electricHeatPumpHouseholds_pct.getValue() );
 						<Orientation>HORIZONTAL</Orientation>
 						<MinValue><![CDATA[0]]></MinValue>
 						<MaxValue><![CDATA[50]]></MaxValue>
-						<Step><![CDATA[1]]></Step>
+						<Step><![CDATA[5]]></Step>
 						<LinkTo>false</LinkTo>
 					</ExtendedProperties>
 				</Control>
@@ -27741,7 +28403,7 @@ f_setHeatingSystemsHouseholds( sl_electricHeatPumpHouseholds_pct.getValue() );
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[f_setHeatingSliders( 0, sl_gasBurnerCompanies_pct, sl_electricHeatPumpCompanies_pct, null, null );
-f_setHeatingSystemsCompanies( sl_electricHeatPumpCompanies_pct.getValue() );
+f_setHeatingSystemsCompanies( sl_gasBurnerCompanies_pct, sl_electricHeatPumpCompanies_pct );
 
 zero_Interface.f_resetSettings();]]></ActionCode>
 					</BasicProperties>
@@ -27796,7 +28458,7 @@ zero_Interface.f_resetSettings();]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[f_setHeatingSliders( 1, sl_gasBurnerCompanies_pct, sl_electricHeatPumpCompanies_pct, null, null );
-f_setHeatingSystemsCompanies( sl_electricHeatPumpCompanies_pct.getValue() );
+f_setHeatingSystemsCompanies( sl_gasBurnerCompanies_pct, sl_electricHeatPumpCompanies_pct);
 
 zero_Interface.f_resetSettings();]]></ActionCode>
 					</BasicProperties>
@@ -28322,14 +28984,16 @@ zero_Interface.f_resetSettings();]]></ActionCode>
 					<BasicProperties Width="100" Height="30">
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
-						<ActionCode><![CDATA[f_setDemandReductionHeatingCompanies( sl_heatDemandReductionCompanies_pct.getValue() );]]></ActionCode>
+						<ActionCode><![CDATA[f_setDemandReductionHeatingCompanies( sl_heatDemandSlidersCompaniesHeatDemandReductionCompanies_pct.getValue());
+
+]]></ActionCode>
 					</BasicProperties>
 					<ExtendedProperties>
 						<DefaultValueCode><![CDATA[0]]></DefaultValueCode>
 						<Orientation>HORIZONTAL</Orientation>
 						<MinValue><![CDATA[0]]></MinValue>
 						<MaxValue><![CDATA[50]]></MaxValue>
-						<Step><![CDATA[1]]></Step>
+						<Step><![CDATA[5]]></Step>
 						<LinkTo>false</LinkTo>
 					</ExtendedProperties>
 				</Control>
@@ -28593,7 +29257,7 @@ zero_Interface.f_resetSettings();]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[f_setHeatingSliders( 0, sl_heatDemandSlidersCompaniesGasBurnerCompanies_pct, sl_heatDemandSlidersCompaniesElectricHeatPumpCompanies_pct, null, null );
-f_setHeatingSystemsCompanies( sl_heatDemandSlidersCompaniesElectricHeatPumpCompanies_pct.getValue() );
+f_setHeatingSystemsCompanies( sl_heatDemandSlidersCompaniesGasBurnerCompanies_pct, sl_heatDemandSlidersCompaniesElectricHeatPumpCompanies_pct);
 
 zero_Interface.f_resetSettings();]]></ActionCode>
 					</BasicProperties>
@@ -28648,7 +29312,7 @@ zero_Interface.f_resetSettings();]]></ActionCode>
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<Enabled>true</Enabled>
 						<ActionCode><![CDATA[f_setHeatingSliders( 1, sl_heatDemandSlidersCompaniesGasBurnerCompanies_pct, sl_heatDemandSlidersCompaniesElectricHeatPumpCompanies_pct, null, null );
-f_setHeatingSystemsCompanies( sl_heatDemandSlidersCompaniesElectricHeatPumpCompanies_pct.getValue() );
+f_setHeatingSystemsCompanies( sl_heatDemandSlidersCompaniesGasBurnerCompanies_pct, sl_heatDemandSlidersCompaniesElectricHeatPumpCompanies_pct);
 
 zero_Interface.f_resetSettings();]]></ActionCode>
 					</BasicProperties>
@@ -28731,7 +29395,7 @@ zero_Interface.f_resetSettings();]]></ActionCode>
 				<Rectangle>
 					<Id>1722338183031</Id>
 					<Name><![CDATA[rect_heatingFunctions]]></Name>
-					<X>90</X><Y>710</Y>
+					<X>40</X><Y>710</Y>
 					<Label><X>10</X><Y>10</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -28744,7 +29408,7 @@ zero_Interface.f_resetSettings();]]></ActionCode>
 					<LineColor>-5952982</LineColor>
 					<LineMaterial>null</LineMaterial>
 					<LineStyle>SOLID</LineStyle>
-					<Width>300</Width>
+					<Width>400</Width>
 					<Height>150</Height>
 					<Rotation>0.0</Rotation>
 					<FillColor>-1</FillColor>
@@ -28753,7 +29417,7 @@ zero_Interface.f_resetSettings();]]></ActionCode>
 				<Text>
 					<Id>1722338183033</Id>
 					<Name><![CDATA[t_heatingFunctionsDescription]]></Name>
-					<X>240</X><Y>720</Y>
+					<X>130</X><Y>720</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -29541,7 +30205,7 @@ zero_Interface.f_resetSettings();]]></ActionCode>
 					<Z>0</Z>
 					<Rotation>0.0</Rotation>
 					<Color>-16777216</Color>
-					<Text><![CDATA[Max spreiden laden elek. trucks]]></Text>
+					<Text><![CDATA[Slim laden]]></Text>
 					<Font>
 						<Name>Dialog</Name>
 						<Size>14</Size>
@@ -29634,11 +30298,25 @@ zero_Interface.f_resetSettings();]]></ActionCode>
 						<ActionCode><![CDATA[if (cb_curtailment.isSelected()) {
 	for (GridConnection GC : zero_Interface.energyModel.f_getGridConnections()) {
 		GC.v_enableCurtailment = true;
+		
+		if (zero_Interface.c_companyUIs.size()>0){
+			UI_company companyUI = zero_Interface.c_companyUIs.get(GC.p_owner.p_connectionOwnerIndexNr);
+			if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == GC) { // should also check the setting of selected GC
+				companyUI.cb_curtailmentCompany.setSelected(true, false);
+			}
+		}
 	}
 }
 else {
 	for (GridConnection GC : zero_Interface.energyModel.f_getGridConnections()) {
 		GC.v_enableCurtailment = false;
+		
+		if (zero_Interface.c_companyUIs.size()>0){
+			UI_company companyUI = zero_Interface.c_companyUIs.get(GC.p_owner.p_connectionOwnerIndexNr);
+			if (companyUI != null && companyUI.c_ownedGridConnections.get(companyUI.v_currentSelectedGCnr) == GC) { // should also check the setting of selected GC
+				companyUI.cb_curtailmentCompany.setSelected(false, false);
+			}
+		}
 	}
 }
 zero_Interface.f_resetSettings();]]></ActionCode>
@@ -30241,7 +30919,7 @@ f_resetNFATOSettings();]]></ActionCode>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>false</ShowLabel>
 					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
-					<BasicProperties Width="95" Height="70">
+					<BasicProperties Width="70" Height="70">
                         <EmbeddedIcon>false</EmbeddedIcon>	
 						<TextColor/>
 						<Enabled>true</Enabled>
@@ -30250,9 +30928,9 @@ f_resetNFATOSettings();]]></ActionCode>
 						<Font Name="Dialog" Size="11" Style="0"/>
 						<DefaultValueCode><![CDATA[2]]></DefaultValueCode>
 						<Orientation>VERTICAL</Orientation>
-						<Button><![CDATA[Levering]]></Button>
-						<Button><![CDATA[Teruglevering]]></Button>
-						<Button><![CDATA[Beide]]></Button>
+						<Button><![CDATA[Delivery]]></Button>
+						<Button><![CDATA[Feed in]]></Button>
+						<Button><![CDATA[Both]]></Button>
 						<LinkTo>false</LinkTo>
 					</ExtendedProperties>
 				</Control>
@@ -32638,7 +33316,8 @@ import java.io.PrintStream;
 
 //Import survey API library
 import com.zenmo.vallum.Vallum;
-]]></Import>
+
+import zeroPackage.ZeroMath;]]></Import>
 			<Generic>false</Generic>
 			<GenericParameter>
 				<Id>1726584205730</Id>
@@ -34551,6 +35230,7 @@ return b;]]></Body>
 			}
 		}
 		catch(Exception e) {
+
 			//Do nothing, cause initialized with null;
 		}
 	}
@@ -34563,8 +35243,8 @@ return b;]]></Body>
 	double[] yearlyElectricityDelivery_kWh_array = (yearlyElectricityDelivery_kWh_list != null) ? yearlyElectricityDelivery_kWh_list.stream().mapToDouble(d -> max(0,d)).toArray() : null;
 	double[] yearlyElectricityFeedin_kWh_array = 	(yearlyElectricityFeedin_kWh_list != null) ? yearlyElectricityFeedin_kWh_list.stream().mapToDouble(d -> max(0,d)).toArray() : null;
 	double[] yearlyElectricityProduction_kWh_array = (yearlyElectricityProduction_kWh_list != null) ? yearlyElectricityProduction_kWh_list.stream().mapToDouble(d -> max(0,d)).toArray() : null;
-
 	
+
 	//Preprocess and add the profiles
 	f_createPreprocessedElectricityProfile(parentGC, yearlyElectricityDelivery_kWh_array, yearlyElectricityFeedin_kWh_array, yearlyElectricityProduction_kWh_array, pvPower_kW);
 
@@ -34609,7 +35289,6 @@ double yearlyDemandHeat_kWh = 0;
 double profileTimeStep_hr = 1;
 double maxPowerGasburner = 0;
 
-
 if(hasHourlyGasData){
 	J_EAProfile profile = new J_EAProfile(parentGC, OL_EnergyCarrierType.HEAT, null, OL_ProfileAssetType.HEATDEMAND ,profileTimeStep_hr);		
 	profile.energyAssetName = parentGC.p_ownerID + " custom heat profile";
@@ -34649,17 +35328,17 @@ else{
 	
 	//Determine heatdemand
 	heatDemand = new J_EAConsumption(parentGC, OL_EnergyAssetType.HEAT_DEMAND, profileName, 0.0, yearlyDemandHeat_kWh, 0.0, 0.0, 0.0, energyModel.p_timeStep_h, null);
-	
-	//Calculate required thermal power
-	if(genericProfiles_data.buildingHeatDemandList_maximum() != null){
-		maxPowerGasburner = yearlyDemandHeat_kWh*genericProfiles_data.buildingHeatDemandList_maximum();
-	}
-	else{
-		maxPowerGasburner = (yearlyDemandHeat_kWh / 8760 * 10);
-	}	
+	maxPowerGasburner = yearlyDemandHeat_kWh*genericProfiles_data.buildingHeatDemandList_maximum();//(yearlyDemandHeat_kWh / 8760 * 10);
 }
 
 //Initialize parameters
+double capacityElectric_kW;
+double efficiency;
+double baseTemperature_degC;
+double outputTemperature_degC;
+String ambientTempType;
+double sourceAssetHeatPower_kW;
+double belowZeroHeatpumpEtaReductionFactor;
 
 switch (parentGC.p_heatingType){ // HOE gaan we om met meerdere heating types in survey???
 
@@ -34669,17 +35348,19 @@ switch (parentGC.p_heatingType){ // HOE gaan we om met meerdere heating types in
 	
 	case HYBRID_HEATPUMP:
 		
-		//Add primary heating asset (heatpump)
-		double capacityElectric_kW = maxPowerGasburner / 3; //-- /3, want is hybride, dus kleiner
-		double efficiency = zero_Interface.energyModel.avgc_data.p_avgEfficiencyHeatpump;
-		double baseTemperature_degC = zero_Interface.energyModel.v_currentAmbientTemperature_degC;
-		double outputTemperature_degC = zero_Interface.energyModel.avgc_data.p_avgOutputTemperatureHeatpump_degC;
-		String ambientTempType = "AIR";
-		double sourceAssetHeatPower_kW = 0;
-		double belowZeroHeatpumpEtaReductionFactor = 1;
-		
-		J_EAConversionHeatPump heatPumpHybrid = new J_EAConversionHeatPump(parentGC, energyModel.p_timeStep_h, capacityElectric_kW, efficiency, baseTemperature_degC, outputTemperature_degC, ambientTempType, sourceAssetHeatPower_kW, belowZeroHeatpumpEtaReductionFactor );
-		zero_Interface.energyModel.c_ambientAirDependentAssets.add(heatPumpHybrid);
+		//Add primary heating asset (heatpump) (if its not part of the basic profile already
+		if(!parentGC.v_hasQuarterHourlyValues || settings.createCurrentElectricityEA()){
+			capacityElectric_kW = maxPowerGasburner / 3; //-- /3, want is hybride, dus kleiner
+			efficiency = zero_Interface.energyModel.avgc_data.p_avgEfficiencyHeatpump;
+			baseTemperature_degC = zero_Interface.energyModel.v_currentAmbientTemperature_degC;
+			outputTemperature_degC = zero_Interface.energyModel.avgc_data.p_avgOutputTemperatureHeatpump_degC;
+			ambientTempType = "AIR";
+			sourceAssetHeatPower_kW = 0;
+			belowZeroHeatpumpEtaReductionFactor = 1;
+			
+			J_EAConversionHeatPump heatPumpHybrid = new J_EAConversionHeatPump(parentGC, energyModel.p_timeStep_h, capacityElectric_kW, efficiency, baseTemperature_degC, outputTemperature_degC, ambientTempType, sourceAssetHeatPower_kW, belowZeroHeatpumpEtaReductionFactor );
+			zero_Interface.energyModel.c_ambientAirDependentAssets.add(heatPumpHybrid);
+		}
 		
 		//Add secondary heating asset (gasburner)
 		efficiency = zero_Interface.energyModel.avgc_data.p_avgEfficiencyGasBurner;
@@ -34706,8 +35387,8 @@ switch (parentGC.p_heatingType){ // HOE gaan we om met meerdere heating types in
 	break;
 	
 	default:
-	traceln("HEATING TYPE NOT FOUND FOR GC ");
-	traceln(parentGC);
+		traceln("HEATING TYPE NOT FOUND FOR GC ");
+		traceln(parentGC);
 }
 
 ]]></Body>
@@ -35102,6 +35783,9 @@ zero_Interface.c_scenarioMap_Current.put(companyGC, current_scenario_list);
 J_scenario_Future future_scenario_list = new J_scenario_Future();
 zero_Interface.c_scenarioMap_Future.put(companyGC, future_scenario_list);
 
+//Set parent
+current_scenario_list.setParentAgent(companyGC);
+future_scenario_list.setParentAgent(companyGC);
 
 ////Electricity (connection and consumption)
 //Initialize contract capacity with 0 for when companies fill in survey already but currently have no connection yet
@@ -35334,7 +36018,7 @@ if (gridConnection.getNaturalGas().getHasConnection() != null && gridConnection.
 f_setHeatingTypeSurvey(companyGC, gridConnection, hasHourlyGasData);
 
 //Set the heating demand profile
-if(!createElectricEA && (companyGC.p_heatingType == OL_GridConnectionHeatingType.HYBRID_HEATPUMP || companyGC.p_heatingType == OL_GridConnectionHeatingType.ELECTRIC_HEATPUMP)){
+if(!createElectricEA && companyGC.p_heatingType == OL_GridConnectionHeatingType.ELECTRIC_HEATPUMP){
 	//Dont create additional Electric heating assets on top of Electricity profile
 }
 else{
@@ -35538,7 +36222,7 @@ if (gridConnection.getTransport().getHasVehicles() != null && gridConnection.get
 		
 		int nbEVTrucks = gridConnection.getTransport().getTrucks().getNumElectricTrucks();		
 		int nbDieselTrucks = gridConnection.getTransport().getTrucks().getNumTrucks() - nbEVTrucks;
-	
+		
 		boolean isDefaultVehicle		= true;
 		double annualTravelDistance_km = 0;
 		double maxChargingPower_kW = avgc_data.p_avgEVMaxChargePowerTruck_kW;
@@ -35563,7 +36247,7 @@ if (gridConnection.getTransport().getHasVehicles() != null && gridConnection.get
 		//create electric vehicles
 		if (createElectricEA){ // Check if electric demand EA should be created
 			for (int j = 0; j< nbEVTrucks; j++){
-			f_addElectricVehicle(companyGC, OL_EnergyAssetType.ELECTRIC_TRUCK, isDefaultVehicle, annualTravelDistance_km, maxChargingPower_kW);
+				f_addElectricVehicle(companyGC, OL_EnergyAssetType.ELECTRIC_TRUCK, isDefaultVehicle, annualTravelDistance_km, maxChargingPower_kW);
 			}
 		}
 		
@@ -35624,41 +36308,42 @@ while (i < gridConnection.getHeat().getHeatingTypes().size()){
 	switch (Heating_Type){
 		
 		case GAS_BOILER:
-		companyGC.p_heatingType = OL_GridConnectionHeatingType.GASBURNER;
-		companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.GASBURNER);
-		break;
+			companyGC.p_heatingType = OL_GridConnectionHeatingType.GASBURNER;
+			companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.GASBURNER);
+			break;
 
 		case HYBRID_HEATPUMP:
-		companyGC.p_heatingType = OL_GridConnectionHeatingType.HYBRID_HEATPUMP;
-		companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.HYBRID_HEATPUMP);
-		break;
+			companyGC.p_heatingType = OL_GridConnectionHeatingType.HYBRID_HEATPUMP;
+			companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.HYBRID_HEATPUMP);
+			break;
 
 		case ELECTRIC_HEATPUMP:
-		companyGC.p_heatingType = OL_GridConnectionHeatingType.ELECTRIC_HEATPUMP;
-		companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.ELECTRIC_HEATPUMP);
-		break;
+			companyGC.p_heatingType = OL_GridConnectionHeatingType.ELECTRIC_HEATPUMP;
+			companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.ELECTRIC_HEATPUMP);
+			break;
 		
 		case DISTRICT_HEATING:
-		companyGC.p_heatingType = OL_GridConnectionHeatingType.DISTRICTHEAT;
-		companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.DISTRICTHEAT);
-		break;
-		
+			companyGC.p_heatingType = OL_GridConnectionHeatingType.DISTRICTHEAT;
+			companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.DISTRICTHEAT);
+			break;
+			
 		case OTHER:
-		companyGC.p_heatingType = OL_GridConnectionHeatingType.NONE;// Other is not supported by the model so: NONE.
-		companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.OTHER);
-		break;
-		
+			companyGC.p_heatingType = OL_GridConnectionHeatingType.NONE;// Other is not supported by the model so: NONE.
+			companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.OTHER);
+			break;
+			
 		default:
-		companyGC.p_heatingType = OL_GridConnectionHeatingType.NONE;
-		traceln("no or incorrect heating type detected for '" + companyGC.p_ownerID + "'");
-		//companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.NONE);
+			companyGC.p_heatingType = OL_GridConnectionHeatingType.NONE;
+			traceln("no or incorrect heating type detected for '" + companyGC.p_ownerID + "'");
+			//companyGC.c_heatingTypes.add(OL_GridConnectionHeatingType.NONE);
 	}
 	i++;
 }
 
 //Set correct primary heating method (p_heatingType) (needed for now, till model can support multiple heating types)
 if (companyGC.c_heatingTypes.size()>1){
-	if (hasHourlyGasData){
+	
+	if (hasHourlyGasData && !companyGC.c_heatingTypes.contains(OL_GridConnectionHeatingType.GASBURNER)){
 		companyGC.p_heatingType = OL_GridConnectionHeatingType.GASBURNER;
 		return;
 	}
@@ -35905,6 +36590,10 @@ zero_Interface.c_scenarioMap_Current.put(companyGC, current_scenario_list);
 
 J_scenario_Future future_scenario_list = new J_scenario_Future();
 zero_Interface.c_scenarioMap_Future.put(companyGC, future_scenario_list);
+
+//Set parent
+current_scenario_list.setParentAgent(companyGC);
+future_scenario_list.setParentAgent(companyGC);
 
 //Add current grid capacity to current (and future, feedin, physical, as no data on plans so assumption it is/stays the same) scenario list
 current_scenario_list.setCurrentContractDeliveryCapacity_kW(companyGC.p_contractedDeliveryCapacity_kW);
@@ -36833,7 +37522,7 @@ if (yearlyElectricityProduction_kWh != null && yearlyElectricityFeedin_kWh != nu
 }
 //traceln(Arrays.stream(profile.a_energyProfile_kWh).sum() + " kWh per jaar at grid connection " + parentGC.p_ownerID + " " + profileName);
 v_remainingElectricityDelivery_kWh -= nettDelivery_kWh;
-
+ 
 if (v_remainingElectricityDelivery_kWh < 0){
 	traceln("v_remainingElectricityConsumption_kWh became negative at GC: %s", parentGC);
 }]]></Body>
@@ -38642,6 +39331,7 @@ return annualElectricityConsumption_kWh;
 public class J_scenario_Current implements Serializable {
 
 	private Agent parentAgent;
+	private boolean isCurrentlyActive = true;
 	private Double currentContractDeliveryCapacity_kW = 0.0;
 	private Double currentContractFeedinCapacity_kW = 0.0;
 	private Double currentPhysicalConnectionCapacity_kW = 0.0;
@@ -38682,6 +39372,10 @@ public class J_scenario_Current implements Serializable {
     // Setters
     public void setParentAgent(Agent parentAgent) {
         this.parentAgent = parentAgent;
+    }
+    
+    public void setIsCurrentlyActive(boolean isCurrentlyActive) {
+        this.isCurrentlyActive = isCurrentlyActive;
     }
     
     public void setCurrentContractDeliveryCapacity_kW(Double currentContractDeliveryCapacity_kW) {
@@ -38773,6 +39467,10 @@ public class J_scenario_Current implements Serializable {
     // Getters
     public Agent getParentAgent() {
         return parentAgent;
+    }
+    
+    public boolean getIsCurrentlyActive() {
+        return isCurrentlyActive;
     }
     
     public Double getCurrentContractDeliveryCapacity_kW() {
@@ -38889,6 +39587,7 @@ public class J_scenario_Current implements Serializable {
 public class J_scenario_Future implements Serializable {
 
 	private Agent parentAgent;
+	private boolean isActiveInFuture = true; //Boolean used to see if gc is active in future scenario
 	private Double requestedContractDeliveryCapacity_kW = 0.0;
 	private Double requestedContractFeedinCapacity_kW = 0.0;
 	private Double requestedPhysicalConnectionCapacity_kW = 0.0;
@@ -38926,6 +39625,10 @@ public class J_scenario_Future implements Serializable {
     // Setters
     public void setParentAgent(Agent parentAgent) {
         this.parentAgent = parentAgent;
+    }
+    
+    public void setIsActiveInFuture(boolean isActiveInFuture) {
+        this.isActiveInFuture = isActiveInFuture;
     }
 
     public void setRequestedContractDeliveryCapacity_kW(Double requestedContractDeliveryCapacity_kW) {
@@ -38988,6 +39691,10 @@ public class J_scenario_Future implements Serializable {
     // Getters
     public Agent getParentAgent() {
         return parentAgent;
+    }
+    
+    public boolean getIsActiveInFuture() {
+        return isActiveInFuture;
     }
     
     public Double getRequestedContractDeliveryCapacity_kW() {


### PR DESCRIPTION
All interactions with the main sliders with the companyUI and vice versa have been reworked. 
- Now fully operational for all sliders (except hydrogen truck slider on main interface (was disabled already). No longer errors when using main interface sliders and companyUI sliders after eachother. 
- Overall quality of life improvements for the user: paused companies can not be found or adjusted now: need to be turned on first. When selected company building dissapears (due to scenario change or something) it is also no longer selected now, etc. Makes it im/less possible for the user to break the model now and cause errors (lets test it to the max). 
- Model is also fully resettable now when using the scenario settings. No longer needed to reload the page to get to the same values at the start of simulation.