### PR TITLE
resultsUI styling fixes + removal of legendscope

### DIFF
--- a/Zero_Interface-Loader.alpx
+++ b/Zero_Interface-Loader.alpx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AnyLogicWorkspace splitVersion="1"
                    WorkspaceVersion="1.9"
-                   AnyLogicVersion="8.9.2.202410172110"
+                   AnyLogicVersion="8.9.2.202410172112"
                    AlpVersion="8.9.2">
 	<Model>
 		<Id>1658477103134</Id>

--- a/_alp/Agents/UI_company/EmbeddedObjects.xml
+++ b/_alp/Agents/UI_company/EmbeddedObjects.xml
@@ -32,9 +32,6 @@
 				</Value>
 			</Parameter>
 			<Parameter>
-				<Name><![CDATA[p_legendsScope]]></Name>
-			</Parameter>
-			<Parameter>
 				<Name><![CDATA[p_previousTotals_Region]]></Name>
 			</Parameter>
 			<Parameter>

--- a/_alp/Agents/UI_company/Levels/Level.level.xml
+++ b/_alp/Agents/UI_company/Levels/Level.level.xml
@@ -2202,7 +2202,6 @@ f_setSimulateYearScreen();</ActionCode>
 						<PresentationFlag>true</PresentationFlag>
 						<ShowLabel>false</ShowLabel>
 						<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
-						<OnClickCode/>
 						<EmbeddedIcon>false</EmbeddedIcon>
 						<Z>0</Z>
 						<Rotation>0.0</Rotation>

--- a/_alp/Agents/Zero_Interface/Code/Functions.java
+++ b/_alp/Agents/Zero_Interface/Code/Functions.java
@@ -552,9 +552,15 @@ uI_Tabs.pop_tabHeating.get(0).f_calculateNumberOfGhostHeatingSystems();
 
 double f_connectResultsUI()
 {/*ALCODESTART::1709716821854*/
-//Set legend settings
-uI_Results.p_legendsScope = f_setLegendsScope();
+//Style resultsUI
+f_styleResultsUI();
 
+//Set ResultsUI radiobutton setup
+if(settings.resultsUIRadioButtonSetup() != null){
+	uI_Results.v_selectedRadioButton = settings.resultsUIRadioButtonSetup();
+}
+
+//Initialize main area collection
 AreaCollection mainArea = uI_Results.add_pop_areaResults(OL_GISObjectType.REGION, "Main");
 uI_Results.v_area = mainArea;
 
@@ -562,10 +568,7 @@ uI_Results.v_area = mainArea;
 mainArea.v_activeProductionEnergyCarriers = energyModel.v_activeProductionEnergyCarriers;
 mainArea.v_activeConsumptionEnergyCarriers = energyModel.v_activeConsumptionEnergyCarriers;
 
-//Set ResultsUI radiobutton setup
-if(settings.resultsUIRadioButtonSetup() != null){
-	uI_Results.v_selectedRadioButton = settings.resultsUIRadioButtonSetup();
-}
+
 
 //Set boolean if it has connection with heatgrid
 for (GridNode GN : energyModel.f_getGridNodesTopLevel()) {
@@ -2749,29 +2752,6 @@ for (GridConnection GC : energyModel.f_getGridConnections()){
 
 /*ALCODEEND*/}
 
-OL_LegendsScope f_setLegendsScope()
-{/*ALCODESTART::1727355134954*/
-//Can be overridden in child if other than default is preferred. 
-OL_LegendsScope p_legendsScope;
-
-switch(p_selectedProjectType){
-
-case BUSINESSPARK:
-	p_legendsScope = OL_LegendsScope.BUSINESSPARK;
-	break;
-	
-case RESIDENTIAL:
-	p_legendsScope = OL_LegendsScope.RESIDENTIAL;
-	break;
-
-default:
-	p_legendsScope = OL_LegendsScope.BUSINESSPARK;
-
-}
-
-return p_legendsScope;
-/*ALCODEEND*/}
-
 double f_projectSpecificOrderedCollectionAdjustments()
 {/*ALCODESTART::1729685968993*/
 //Function that can be used to make project specific adjustments to the ordered collection
@@ -3927,5 +3907,10 @@ else {
 	uI_Results.v_selectedObjectType = OL_GISObjectType.REGION;
 }
 uI_Results.f_showCorrectChart();
+/*ALCODEEND*/}
+
+double f_styleResultsUI()
+{/*ALCODESTART::1736442051389*/
+uI_Results.f_styleAllCharts(v_backgroundColor, lavender, 1.0, LINE_STYLE_SOLID);
 /*ALCODEEND*/}
 

--- a/_alp/Agents/Zero_Interface/Code/Functions.xml
+++ b/_alp/Agents/Zero_Interface/Code/Functions.xml
@@ -68,7 +68,7 @@
 		<Id>1702045084338</Id>
 		<Name><![CDATA[f_styleAreas]]></Name>
 		<X>-670</X>
-		<Y>350</Y>
+		<Y>340</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -88,7 +88,7 @@
 		<Id>1702385530773</Id>
 		<Name><![CDATA[f_styleSimulationAreas]]></Name>
 		<X>-670</X>
-		<Y>330</Y>
+		<Y>320</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -108,7 +108,7 @@
 		<Id>1705499586056</Id>
 		<Name><![CDATA[f_styleGridNodes]]></Name>
 		<X>-670</X>
-		<Y>380</Y>
+		<Y>370</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -128,7 +128,7 @@
 		<Id>1705505495599</Id>
 		<Name><![CDATA[f_styleMVLV]]></Name>
 		<X>-650</X>
-		<Y>460</Y>
+		<Y>450</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -148,7 +148,7 @@
 		<Id>1705505509120</Id>
 		<Name><![CDATA[f_styleHVMV]]></Name>
 		<X>-650</X>
-		<Y>400</Y>
+		<Y>390</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -261,7 +261,7 @@
 		<Id>1709716821854</Id>
 		<Name><![CDATA[f_connectResultsUI]]></Name>
 		<X>-670</X>
-		<Y>590</Y>
+		<Y>560</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -277,7 +277,7 @@
 		<Id>1709716821856</Id>
 		<Name><![CDATA[f_updateUIresultsMainArea]]></Name>
 		<X>-650</X>
-		<Y>650</Y>
+		<Y>620</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -293,7 +293,7 @@
 		<Id>1709716821860</Id>
 		<Name><![CDATA[f_updateUIresultsEnergyCoop]]></Name>
 		<X>-650</X>
-		<Y>689.467</Y>
+		<Y>659.467</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -333,7 +333,7 @@
 		<Id>1712584842532</Id>
 		<Name><![CDATA[f_updateUIresultsGridNode]]></Name>
 		<X>-650</X>
-		<Y>670</Y>
+		<Y>640</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -357,7 +357,7 @@
 		<Id>1714043663127</Id>
 		<Name><![CDATA[f_setGridNodeCongestionColor]]></Name>
 		<X>-650</X>
-		<Y>500</Y>
+		<Y>490</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -481,7 +481,7 @@
 		<Id>1715157302225</Id>
 		<Name><![CDATA[f_projectSpecificSettings]]></Name>
 		<X>-670</X>
-		<Y>260</Y>
+		<Y>250</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -497,7 +497,7 @@
 		<Id>1715859145993</Id>
 		<Name><![CDATA[f_UIStartup]]></Name>
 		<X>-670</X>
-		<Y>220</Y>
+		<Y>210</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -535,7 +535,7 @@
 		<Name><![CDATA[f_setStartView]]></Name>
 		<Description><![CDATA[Function used to set the starting view of the simulation.]]></Description>
 		<X>-670</X>
-		<Y>240</Y>
+		<Y>230</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -719,7 +719,7 @@
 		<Id>1720799287420</Id>
 		<Name><![CDATA[f_updateUIresultsGridConnection]]></Name>
 		<X>-650</X>
-		<Y>710</Y>
+		<Y>680</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -743,7 +743,7 @@
 		<Id>1720820424632</Id>
 		<Name><![CDATA[f_updateYearlyGCData]]></Name>
 		<X>-620</X>
-		<Y>770</Y>
+		<Y>740</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -767,7 +767,7 @@
 		<Id>1720820539394</Id>
 		<Name><![CDATA[f_updateWeeklyGCData]]></Name>
 		<X>-620</X>
-		<Y>790</Y>
+		<Y>760</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -791,7 +791,7 @@
 		<Id>1720820888674</Id>
 		<Name><![CDATA[f_updateBelastingduurKromme]]></Name>
 		<X>-620</X>
-		<Y>810</Y>
+		<Y>780</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -839,7 +839,7 @@
 		<Id>1721991420806</Id>
 		<Name><![CDATA[f_setGridTopologyColors]]></Name>
 		<X>-650</X>
-		<Y>480</Y>
+		<Y>470</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -855,7 +855,7 @@
 		<Id>1721991963719</Id>
 		<Name><![CDATA[f_styleSUBMV]]></Name>
 		<X>-650</X>
-		<Y>440</Y>
+		<Y>430</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -875,7 +875,7 @@
 		<Id>1721992103665</Id>
 		<Name><![CDATA[f_styleMVMV]]></Name>
 		<X>-650</X>
-		<Y>420</Y>
+		<Y>410</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1023,7 +1023,7 @@
 		<Id>1725439643960</Id>
 		<Name><![CDATA[f_updateTotalLiveDataSets]]></Name>
 		<X>-650</X>
-		<Y>850</Y>
+		<Y>820</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1039,7 +1039,7 @@
 		<Id>1725440073691</Id>
 		<Name><![CDATA[f_addTimeStepTotalLiveDataSets]]></Name>
 		<X>-625</X>
-		<Y>870</Y>
+		<Y>840</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1091,7 +1091,7 @@
 		<Id>1726068314849</Id>
 		<Name><![CDATA[f_projectSpecificStyling]]></Name>
 		<X>-670</X>
-		<Y>280</Y>
+		<Y>270</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1107,23 +1107,7 @@
 		<Id>1727085747538</Id>
 		<Name><![CDATA[f_updatePreviousTotalsGC]]></Name>
 		<X>-650</X>
-		<Y>630</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Body xmlns:al="http://anylogic.com"/>
-	</Function>
-	<Function AccessType="default" StaticFunction="false">
-		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
-		<ReturnType>OL_LegendsScope</ReturnType>
-		<Id>1727355134954</Id>
-		<Name><![CDATA[f_setLegendsScope]]></Name>
-		<X>-650</X>
-		<Y>610</Y>
+		<Y>600</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1155,7 +1139,7 @@
 		<Id>1733490994454</Id>
 		<Name><![CDATA[f_updateVariablesOfGCData]]></Name>
 		<X>-620</X>
-		<Y>730</Y>
+		<Y>700</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1179,7 +1163,7 @@
 		<Id>1733857321674</Id>
 		<Name><![CDATA[f_updateLiveDataSets]]></Name>
 		<X>-620</X>
-		<Y>750</Y>
+		<Y>720</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1203,7 +1187,7 @@
 		<Id>1733857328199</Id>
 		<Name><![CDATA[f_addTimeStepLiveDataSets]]></Name>
 		<X>-620</X>
-		<Y>830</Y>
+		<Y>800</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1227,7 +1211,7 @@
 		<Id>1734361725171</Id>
 		<Name><![CDATA[f_updateActiveAssetBooleansGC]]></Name>
 		<X>-620</X>
-		<Y>910</Y>
+		<Y>880</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1251,7 +1235,7 @@
 		<Id>1734368189128</Id>
 		<Name><![CDATA[f_updateActiveAssetBooleans]]></Name>
 		<X>-650</X>
-		<Y>890</Y>
+		<Y>860</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1612,8 +1596,8 @@
 		<ReturnType>double</ReturnType>
 		<Id>1736425260898</Id>
 		<Name><![CDATA[f_EHubCapacityDataSets]]></Name>
-		<X>-980</X>
-		<Y>925</Y>
+		<X>-650</X>
+		<Y>930</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1628,8 +1612,8 @@
 		<ReturnType>double</ReturnType>
 		<Id>1736425260900</Id>
 		<Name><![CDATA[f_updateLiveEHubCapacityDataSets]]></Name>
-		<X>-980</X>
-		<Y>945</Y>
+		<X>-650</X>
+		<Y>950</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1644,8 +1628,8 @@
 		<ReturnType>double</ReturnType>
 		<Id>1736425260902</Id>
 		<Name><![CDATA[f_fillAreaCollectionsOfIndividualGCs]]></Name>
-		<X>-980</X>
-		<Y>905</Y>
+		<X>-650</X>
+		<Y>910</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1677,6 +1661,22 @@
 			<Name><![CDATA[clicky]]></Name>
 			<Type><![CDATA[double]]></Type>
 		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="default" StaticFunction="false">
+		<ReturnModificator>VOID</ReturnModificator>
+		<ReturnType>double</ReturnType>
+		<Id>1736442051389</Id>
+		<Name><![CDATA[f_styleResultsUI]]></Name>
+		<X>-650</X>
+		<Y>580</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
 </Functions>

--- a/_alp/Agents/Zero_Interface/EmbeddedObjects.xml
+++ b/_alp/Agents/Zero_Interface/EmbeddedObjects.xml
@@ -139,7 +139,7 @@
 		<Id>1716193013122</Id>
 		<Name><![CDATA[uI_Results]]></Name>
 		<X>-670</X>
-		<Y>570</Y>
+		<Y>540</Y>
 		<Label>
 			<X>15</X>
 			<Y>0</Y>
@@ -165,9 +165,6 @@
 				<Value Class="CodeValue">
 					<Code><![CDATA[energyModel]]></Code>
 				</Value>
-			</Parameter>
-			<Parameter>
-				<Name><![CDATA[p_legendsScope]]></Name>
 			</Parameter>
 			<Parameter>
 				<Name><![CDATA[p_previousTotals_Region]]></Name>

--- a/_alp/Agents/Zero_Interface/Levels/Level.level.xml
+++ b/_alp/Agents/Zero_Interface/Levels/Level.level.xml
@@ -3138,7 +3138,7 @@ b_updateCongestionColors = false;
 		<Id>1702552223737</Id>
 		<Name><![CDATA[t_stylingFunctions]]></Name>
 		<X>-680</X>
-		<Y>300</Y>
+		<Y>290</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -3730,7 +3730,7 @@ van het gebied, en de huidige gasconsumptie voor verwarming.]]></Text>
 		<Id>1710174312959</Id>
 		<Name><![CDATA[t_resultsUIFunctions]]></Name>
 		<X>-680</X>
-		<Y>540</Y>
+		<Y>510</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -3780,7 +3780,7 @@ van het gebied, en de huidige gasconsumptie voor verwarming.]]></Text>
 		<Id>1713431901010</Id>
 		<Name><![CDATA[t_initializationFunctions]]></Name>
 		<X>-680</X>
-		<Y>190</Y>
+		<Y>180</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -4033,7 +4033,7 @@ van het gebied, en de huidige gasconsumptie voor verwarming.]]></Text>
 		<Id>1715951689412</Id>
 		<Name><![CDATA[t_inputParameters]]></Name>
 		<X>-680</X>
-		<Y>60</Y>
+		<Y>50</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -5290,8 +5290,8 @@ b_resultsUpToDate = true;
 	<Rectangle>
 		<Id>1734442437753</Id>
 		<Name><![CDATA[rect_filterFunctions]]></Name>
-		<X>-1080</X>
-		<Y>360</Y>
+		<X>-1500</X>
+		<Y>0</Y>
 		<Label>
 			<X>10</X>
 			<Y>10</Y>
@@ -5366,8 +5366,8 @@ b_resultsUpToDate = true;
 	<Group>
 		<Id>1734444441402</Id>
 		<Name><![CDATA[gr_filterInterface]]></Name>
-		<X>-1050</X>
-		<Y>1200</Y>
+		<X>-1350</X>
+		<Y>740</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>

--- a/_alp/Agents/Zero_Interface/Variables.xml
+++ b/_alp/Agents/Zero_Interface/Variables.xml
@@ -2042,7 +2042,7 @@
 		<Id>1715867611441</Id>
 		<Name><![CDATA[map_centre_latitude]]></Name>
 		<X>-670</X>
-		<Y>110</Y>
+		<Y>100</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2067,7 +2067,7 @@
 		<Id>1715867648777</Id>
 		<Name><![CDATA[map_centre_longitude]]></Name>
 		<X>-670</X>
-		<Y>130</Y>
+		<Y>120</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2092,7 +2092,7 @@
 		<Id>1724757837316</Id>
 		<Name><![CDATA[p_selectedProjectType]]></Name>
 		<X>-670</X>
-		<Y>90</Y>
+		<Y>80</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2117,7 +2117,7 @@
 		<Id>1727251571552</Id>
 		<Name><![CDATA[settings]]></Name>
 		<X>-670</X>
-		<Y>170</Y>
+		<Y>160</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2143,7 +2143,7 @@
 		<Id>1728030131094</Id>
 		<Name><![CDATA[map_scale]]></Name>
 		<X>-670</X>
-		<Y>150</Y>
+		<Y>140</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>


### PR DESCRIPTION
 legendscope is no longer needed, has been replaced by booleans per asset in areaCollection
+ proper styling of resultsUI, fixes certain issues, and gives the possiblity to override resultsUI styling in child.