### PR TITLE
Switch to the live plots

### DIFF
--- a/Zero_Interface-Loader.alpx
+++ b/Zero_Interface-Loader.alpx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AnyLogicWorkspace splitVersion="1"
                    WorkspaceVersion="1.9"
-                   AnyLogicVersion="8.9.2.202410172110"
+                   AnyLogicVersion="8.9.2.202410172112"
                    AlpVersion="8.9.2">
 	<Model>
 		<Id>1658477103134</Id>

--- a/_alp/Agents/Zero_Interface/Code/Functions.java
+++ b/_alp/Agents/Zero_Interface/Code/Functions.java
@@ -575,6 +575,11 @@ double f_resetSettings()
 b_resultsUpToDate = false;
 gr_simulateYearScreenSmall.setVisible(true);
 
+// Switch to the live plots and do not allow the user to switch away from the live plot when the year is not yet simulated
+uI_Results.getRadioButtons().setValue(0, true);
+uI_Results.chartProfielen.getPeriodRadioButton().setValue(0, true);
+uI_Results.f_setNonLivePlotRadioButtons(false);
+
 uI_Results.f_updateActiveAssetBooleans(b_multiSelect, c_selectedGridConnections);
 runSimulation();
 

--- a/_alp/Agents/Zero_Interface/Code/Functions.xml
+++ b/_alp/Agents/Zero_Interface/Code/Functions.xml
@@ -122,7 +122,7 @@
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="default" StaticFunction="false">
+	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1705505495599</Id>
@@ -142,7 +142,7 @@
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="default" StaticFunction="false">
+	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1705505509120</Id>
@@ -287,7 +287,7 @@
 		<ShowLabel>true</ShowLabel>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="protected" StaticFunction="false">
+	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1714043663127</Id>
@@ -689,7 +689,7 @@
 		<ShowLabel>true</ShowLabel>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="default" StaticFunction="false">
+	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1721991963719</Id>
@@ -709,7 +709,7 @@
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="default" StaticFunction="false">
+	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1721992103665</Id>

--- a/_alp/Agents/Zero_Interface/Levels/Level.level.xml
+++ b/_alp/Agents/Zero_Interface/Levels/Level.level.xml
@@ -5070,7 +5070,7 @@ else {
 				<LineMaterial>null</LineMaterial>
 				<LineStyle>DASHED</LineStyle>
 				<Width>460</Width>
-				<Height>224</Height>
+				<Height>180</Height>
 				<Rotation>0.0</Rotation>
 				<FillColor>-1</FillColor>
 				<FillColorCode>v_themeColor</FillColorCode>
@@ -5080,7 +5080,7 @@ else {
 				<Id>1709717180371</Id>
 				<Name><![CDATA[gr_simulateYearToCalculateKPIsSmall]]></Name>
 				<X>10</X>
-				<Y>70</Y>
+				<Y>50</Y>
 				<Label>
 					<X>10</X>
 					<Y>0</Y>
@@ -5120,7 +5120,7 @@ new Thread( () -&gt; {
 }).start();
 
 b_resultsUpToDate = true;
-</OnClickCode>
+uI_Results.f_setNonLivePlotRadioButtons(true);</OnClickCode>
 				<EmbeddedIcon>false</EmbeddedIcon>
 				<Z>0</Z>
 				<Rotation>0.0</Rotation>
@@ -5219,7 +5219,7 @@ b_resultsUpToDate = true;
 				<LineMaterial>null</LineMaterial>
 				<LineStyle>DASHED</LineStyle>
 				<Width>460</Width>
-				<Height>224</Height>
+				<Height>250</Height>
 				<Rotation>0.0</Rotation>
 				<FillColor>-369756683</FillColor>
 				<FillMaterial>null</FillMaterial>

--- a/_alp/Agents/tabElectricity/Code/Functions.java
+++ b/_alp/Agents/tabElectricity/Code/Functions.java
@@ -216,7 +216,7 @@ else if ( v_currentNbChargers < desiredNbOfChargers ){
 		
 		if( charger != null ){
 			String profileName = charger.p_chargingProfileName;
-			J_EAProfile profile = new J_EAProfile(charger, OL_EnergyCarrierType.ELECTRICITY, null, OL_ProfileAssetType.CHARGING, zero_Interface.energyModel.p_timeStep_h);		
+			J_EAProfile profile = new J_EAProfile(charger, OL_EnergyCarriers.ELECTRICITY, null, OL_ProfileAssetType.CHARGING, zero_Interface.energyModel.p_timeStep_h);		
 			profile.energyAssetName = "charging profile";
 			List<Double> quarterlyEnergyDemand_kWh = selectValues(double.class, "SELECT " + profileName + " FROM charging_profiles;");			
 			profile.a_energyProfile_kWh = quarterlyEnergyDemand_kWh.stream().mapToDouble(d -> max(0,d)).map( d -> d / 4).toArray();

--- a/_alp/Agents/tabElectricity/Code/Functions.xml
+++ b/_alp/Agents/tabElectricity/Code/Functions.xml
@@ -73,7 +73,6 @@
 		<ReturnType>double</ReturnType>
 		<Id>1722256239566</Id>
 		<Name><![CDATA[f_setPublicChargingStations]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>810</X>
 		<Y>430</Y>
 		<Label>
@@ -94,7 +93,6 @@
 		<ReturnType>double</ReturnType>
 		<Id>1722256239578</Id>
 		<Name><![CDATA[f_setDieselVehiclesAtPublicParkingHouses]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>830</X>
 		<Y>490</Y>
 		<Label>
@@ -126,12 +124,11 @@
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="default" StaticFunction="false">
+	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1722256291599</Id>
 		<Name><![CDATA[f_setResidentialBatteries]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>810</X>
 		<Y>570</Y>
 		<Label>
@@ -152,7 +149,6 @@
 		<ReturnType>double</ReturnType>
 		<Id>1722261212790</Id>
 		<Name><![CDATA[f_setEVsAtPrivateParkingHouses]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>810</X>
 		<Y>540</Y>
 		<Label>
@@ -184,13 +180,12 @@
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="default" StaticFunction="false">
+	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1724164287280</Id>
 		<Name><![CDATA[f_setGridBatteries]]></Name>
 		<Description><![CDATA[Function that changes the electric capacity of the energy asset of the "Wind Farm". Takes an amount of MW as a parameter. The variables for amount of installed Wind are updated automatically in the zero_engine. The function also modifies the connection capacity of the energy production site to match the new installed Wind Power.]]></Description>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>810</X>
 		<Y>674</Y>
 		<Label>

--- a/_alp/Agents/tabElectricity/Levels/Level.level.xml
+++ b/_alp/Agents/tabElectricity/Levels/Level.level.xml
@@ -29,7 +29,6 @@
 	<Group>
 		<Id>1722249610010</Id>
 		<Name><![CDATA[gr_electricityDemandSlidersResidentialArea]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>965</X>
 		<Y>175</Y>
 		<Label>
@@ -1241,7 +1240,6 @@ if( zero_Interface.rb_buildingColors.getValue() == 2){
 	<Rectangle>
 		<Id>1722334712260</Id>
 		<Name><![CDATA[rect_residentialFunctions]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>780</X>
 		<Y>370</Y>
 		<Label>
@@ -1268,7 +1266,6 @@ if( zero_Interface.rb_buildingColors.getValue() == 2){
 	<Text>
 		<Id>1722334744018</Id>
 		<Name><![CDATA[t_residentialFunctionsDescription]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>980</X>
 		<Y>380</Y>
 		<Label>

--- a/_alp/Agents/tabElectricity/Variables.xml
+++ b/_alp/Agents/tabElectricity/Variables.xml
@@ -47,7 +47,6 @@
 	<Variable Class="PlainVariable">
 		<Id>1722258980135</Id>
 		<Name><![CDATA[v_currentNbChargers]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>830</X>
 		<Y>470</Y>
 		<Label>
@@ -67,7 +66,6 @@
 	<Variable Class="Parameter">
 		<Id>1722259487682</Id>
 		<Name><![CDATA[p_nbChargersInDatabase]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>828</X>
 		<Y>450</Y>
 		<Label>
@@ -96,7 +94,6 @@
 	<Variable Class="Parameter">
 		<Id>1722259487696</Id>
 		<Name><![CDATA[p_minPublicChargerSlider]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>808</X>
 		<Y>620</Y>
 		<Label>
@@ -122,7 +119,6 @@
 	<Variable Class="Parameter">
 		<Id>1722259487705</Id>
 		<Name><![CDATA[p_minPVHouseholdSlider]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>808</X>
 		<Y>640</Y>
 		<Label>


### PR DESCRIPTION
Should be merged together with: https://github.com/Zenmo/zero_results_UI/pull/36
- Switch to the live plots and do not allow the user to switch away from the live plot when the year is not yet simulated
- Several functions are now public so that project Interfaces can override them