### PR TITLE
bugfix total installed pv

### DIFF
--- a/_alp/Agents/tabElectricity/Code/Functions.java
+++ b/_alp/Agents/tabElectricity/Code/Functions.java
@@ -177,7 +177,6 @@ else {
 			J_EAProduction productionAsset = new J_EAProduction ( house, OL_EnergyAssetType.PHOTOVOLTAIC, assetName, installedPVCapacity_kW, capacityHeat_kW, yearlyProductionMethane_kWh, yearlyProductionHydrogen_kWh, zero_Interface.energyModel.p_timeStep_h, outputTemperature_degC, zero_Interface.energyModel.pp_solarPVproduction );
 			zero_Interface.c_orderedPVSystems.remove(house);
 			zero_Interface.c_orderedPVSystems.add(0, house);
-			zero_Interface.energyModel.v_liveAssetsMetaData.totalInstalledPVPower_kW += installedPVCapacity_kW;
 			nbHousesWithPV ++;	
 		}
 	}


### PR DESCRIPTION
It is not needed to change this value when adding / removing or setting the capacity of a production asset. This is all handled in the engine. Either in the asset itself or in the GC's connect_to_JEA / remove_the_JEA functions