### PR TITLE
small bugfix

### DIFF
--- a/_alp/Agents/Zero_Interface/Code/Functions.java
+++ b/_alp/Agents/Zero_Interface/Code/Functions.java
@@ -1477,7 +1477,7 @@ else{//Filtered GC returns GC
 	
 	//Set graphs	
 	if(c_selectedGridConnections.size()>1){
-		v_customEnergyCoop = energyModel.f_addEnergyCoop(c_selectedGridConnections);
+		v_customEnergyCoop = energyModel.f_addEnergyCoop(new ArrayList<GridConnection>(c_selectedGridConnections));
 		uI_Results.f_updateResultsUI(v_customEnergyCoop);
 	}
 	else{


### PR DESCRIPTION
the EnergyCoop that is instantiated from the filter function contained a pointer to the selected gridconnections in the Zero_Interface, instead of a copy of the list of GCs