### PR TITLE
adding auto fit map bounds on startup function

### DIFF
--- a/_alp/Agents/UI_company/Code/Functions.java
+++ b/_alp/Agents/UI_company/Code/Functions.java
@@ -1729,6 +1729,9 @@ gr_simulateYearScreen.setVisible(true);
 if(!b_runningMainInterfaceScenarioSettings && !b_runningMainInterfaceSlider){
 	//Set it for main interface as well
 	zero_Interface.f_resetSettings();
+	
+	//Update variable to change to custom scenario
+	zero_Interface.b_changeToCustomScenario = true;
 }
 /*ALCODEEND*/}
 

--- a/_alp/Agents/Zero_Interface/Code/Events.java
+++ b/_alp/Agents/Zero_Interface/Code/Events.java
@@ -1,8 +1,5 @@
 void e_calculateEnergyBalance()
 {/*ALCODESTART::1658497469833*/
-if (v_timeStepsElapsed <= 1) {
-	f_setStartView();
-}
 // Trigger timestep in energymodel for continuous simulation ('interactive mode')
 energyModel.f_runTimestep();
 v_timeStepsElapsed ++;
@@ -25,5 +22,10 @@ if(c_selectedGridConnections.size() > 0 && c_selectedGridConnections.get(0).v_en
 
 // Get the weather info
 f_getWeatherInfo();
+/*ALCODEEND*/}
+
+void e_setStartView()
+{/*ALCODESTART::1743509682728*/
+f_setStartView();
 /*ALCODEEND*/}
 

--- a/_alp/Agents/Zero_Interface/Code/Events.xml
+++ b/_alp/Agents/Zero_Interface/Code/Events.xml
@@ -39,4 +39,39 @@
 		</Properties>
 		<Action xmlns:al="http://anylogic.com"/>
 	</Event>
+	<Event>
+		<Id>1743509682728</Id>
+		<Name><![CDATA[e_setStartView]]></Name>
+		<X>-670</X>
+		<Y>275</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties TriggerType="timeout" Mode="occuresOnce">
+			<Timeout Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</Timeout>
+			<Rate Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="RateUnits">PER_HOUR</Unit>
+			</Rate>
+			<OccurrenceAtTime>true</OccurrenceAtTime>
+			<OccurrenceDate>1743580800000</OccurrenceDate>
+			<OccurrenceTime Class="CodeUnitValue">
+				<Code><![CDATA[0]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</OccurrenceTime>
+			<RecurrenceCode Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</RecurrenceCode>
+			<Condition>false</Condition>
+		</Properties>
+		<Action xmlns:al="http://anylogic.com"/>
+	</Event>
 </Events>

--- a/_alp/Agents/Zero_Interface/Code/Functions.java
+++ b/_alp/Agents/Zero_Interface/Code/Functions.java
@@ -801,18 +801,6 @@ GISRegion gisregion = new GISRegion(map, gisTokens);
 return gisregion;
 /*ALCODEEND*/}
 
-double f_setStartView()
-{/*ALCODESTART::1715869498509*/
-map.setCenterLatitude(map_centre_latitude);
-map.setCenterLongitude(map_centre_longitude);
-
-if(map_scale != null){
-	map.setMapScale(map_scale);
-}
-
-va_Interface.navigateTo();
-/*ALCODEEND*/}
-
 double f_enableTraceln(PrintStream originalPrintStream)
 {/*ALCODESTART::1716419446045*/
 System.setOut(originalPrintStream);
@@ -2083,5 +2071,62 @@ double f_setForcedClickScreen(boolean showForcedClickScreen,String forcedClickSc
 t_forcedClickMessage.setText(forcedClickScreenText);
 
 gr_forceMapSelection.setVisible(showForcedClickScreen);
+/*ALCODEEND*/}
+
+double f_setMapViewBounds(ArrayList<GIS_Object> GISObjects)
+{/*ALCODESTART::1743509491686*/
+// Initialize min and max values
+double minLat = Double.MAX_VALUE;
+double maxLat = Double.MIN_VALUE;
+double minLon = Double.MAX_VALUE;
+double maxLon = Double.MIN_VALUE;
+ 
+// Loop through all GISRegions and find the bounding box
+for(GIS_Object go : GISObjects){
+	
+	GISRegion region = go.gisRegion;
+    double[] points = region.getPoints(); // Get the boundary points of the region
+ 
+    for (int i = 0; i < points.length; i += 2) { // i+=2 because data is in lat, lon pairs
+        double lat = points[i];       // Latitude
+        double lon = points[i + 1];   // Longitude
+ 
+ 
+ 
+        // Update min/max latitude and longitude
+        minLat = Math.min(minLat, lat);
+        maxLat = Math.max(maxLat, lat);
+        minLon = Math.min(minLon, lon);
+        maxLon = Math.max(maxLon, lon);
+    }
+}
+
+//Make it slightly bigger, so it isnt exact on the line of the regions
+minLat = minLat - 0.0001;
+maxLat = maxLat + 0.0001;
+minLon = minLon - 0.0001;
+maxLon = maxLon + 0.0001;
+        
+// Set the map to fit the calculated bounds
+map.fitBounds(minLat, minLon, maxLat, maxLon);
+/*ALCODEEND*/}
+
+double f_setStartView()
+{/*ALCODESTART::1743518032245*/
+if(map_centre_latitude != 0 && map_centre_longitude != 0){
+	map.setCenterLatitude(map_centre_latitude);
+	map.setCenterLongitude(map_centre_longitude);
+}
+else{
+	ArrayList<GIS_Object> gisObjects_regions = new ArrayList<GIS_Object>(findAll(energyModel.pop_GIS_Objects, gisObject -> gisObject.p_GISObjectType == OL_GISObjectType.REGION));
+	
+	f_setMapViewBounds(gisObjects_regions);
+}
+
+if(map_scale != null){
+	map.setMapScale(map_scale);
+}
+
+va_Interface.navigateTo();
 /*ALCODEEND*/}
 

--- a/_alp/Agents/Zero_Interface/Code/Functions.xml
+++ b/_alp/Agents/Zero_Interface/Code/Functions.xml
@@ -68,7 +68,7 @@
 		<Id>1702045084338</Id>
 		<Name><![CDATA[f_styleAreas]]></Name>
 		<X>-670</X>
-		<Y>350</Y>
+		<Y>371</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -88,7 +88,7 @@
 		<Id>1702385530773</Id>
 		<Name><![CDATA[f_styleSimulationAreas]]></Name>
 		<X>-670</X>
-		<Y>330</Y>
+		<Y>351</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -108,7 +108,7 @@
 		<Id>1705499586056</Id>
 		<Name><![CDATA[f_styleGridNodes]]></Name>
 		<X>-670</X>
-		<Y>370</Y>
+		<Y>391</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -128,7 +128,7 @@
 		<Id>1705505495599</Id>
 		<Name><![CDATA[f_styleMVLV]]></Name>
 		<X>-650</X>
-		<Y>450</Y>
+		<Y>471</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -148,7 +148,7 @@
 		<Id>1705505509120</Id>
 		<Name><![CDATA[f_styleHVMV]]></Name>
 		<X>-650</X>
-		<Y>390</Y>
+		<Y>411</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -168,7 +168,7 @@
 		<Id>1705925024602</Id>
 		<Name><![CDATA[f_setUITabs]]></Name>
 		<X>-670</X>
-		<Y>690</Y>
+		<Y>701</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -261,7 +261,7 @@
 		<Id>1709716821854</Id>
 		<Name><![CDATA[f_connectResultsUI]]></Name>
 		<X>-670</X>
-		<Y>570</Y>
+		<Y>591</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -293,7 +293,7 @@
 		<Id>1714043663127</Id>
 		<Name><![CDATA[f_setGridNodeCongestionColor]]></Name>
 		<X>-650</X>
-		<Y>490</Y>
+		<Y>511</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -417,7 +417,7 @@
 		<Id>1715157302225</Id>
 		<Name><![CDATA[f_projectSpecificSettings]]></Name>
 		<X>-670</X>
-		<Y>250</Y>
+		<Y>230</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -462,23 +462,6 @@
 			<Name><![CDATA[gisTokens]]></Name>
 			<Type><![CDATA[double[]]]></Type>
 		</Parameter>
-		<Body xmlns:al="http://anylogic.com"/>
-	</Function>
-	<Function AccessType="protected" StaticFunction="false">
-		<ReturnModificator>VOID</ReturnModificator>
-		<ReturnType>double</ReturnType>
-		<Id>1715869498509</Id>
-		<Name><![CDATA[f_setStartView]]></Name>
-		<Description><![CDATA[Function used to set the starting view of the simulation.]]></Description>
-		<X>-670</X>
-		<Y>230</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
 	<Function AccessType="protected" StaticFunction="false">
@@ -563,7 +546,7 @@
 		<Id>1718288402102</Id>
 		<Name><![CDATA[f_updateMainInterfaceSliders]]></Name>
 		<X>-670</X>
-		<Y>730</Y>
+		<Y>741</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -655,7 +638,7 @@
 		<Id>1721991420806</Id>
 		<Name><![CDATA[f_setGridTopologyColors]]></Name>
 		<X>-650</X>
-		<Y>470</Y>
+		<Y>491</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -671,7 +654,7 @@
 		<Id>1721991963719</Id>
 		<Name><![CDATA[f_styleSUBMV]]></Name>
 		<X>-650</X>
-		<Y>430</Y>
+		<Y>451</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -691,7 +674,7 @@
 		<Id>1721992103665</Id>
 		<Name><![CDATA[f_styleMVMV]]></Name>
 		<X>-650</X>
-		<Y>410</Y>
+		<Y>431</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -859,7 +842,7 @@
 		<Id>1725977409304</Id>
 		<Name><![CDATA[f_setSliderPresets]]></Name>
 		<X>-670</X>
-		<Y>710</Y>
+		<Y>721</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -875,7 +858,7 @@
 		<Id>1726068314849</Id>
 		<Name><![CDATA[f_projectSpecificStyling]]></Name>
 		<X>-670</X>
-		<Y>270</Y>
+		<Y>250</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1255,7 +1238,7 @@
 		<Id>1736442051389</Id>
 		<Name><![CDATA[f_styleResultsUI]]></Name>
 		<X>-650</X>
-		<Y>590</Y>
+		<Y>611</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1395,6 +1378,42 @@
 			<Name><![CDATA[forcedClickScreenText]]></Name>
 			<Type><![CDATA[String]]></Type>
 		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="default" StaticFunction="false">
+		<ReturnModificator>VOID</ReturnModificator>
+		<ReturnType>double</ReturnType>
+		<Id>1743509491686</Id>
+		<Name><![CDATA[f_setMapViewBounds]]></Name>
+		<X>-480</X>
+		<Y>-60</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[GISObjects]]></Name>
+			<Type><![CDATA[ArrayList<GIS_Object>]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="default" StaticFunction="false">
+		<ReturnModificator>VOID</ReturnModificator>
+		<ReturnType>double</ReturnType>
+		<Id>1743518032245</Id>
+		<Name><![CDATA[f_setStartView]]></Name>
+		<X>-640</X>
+		<Y>295</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
 </Functions>

--- a/_alp/Agents/Zero_Interface/Code/Functions.xml
+++ b/_alp/Agents/Zero_Interface/Code/Functions.xml
@@ -1400,7 +1400,7 @@
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="default" StaticFunction="false">
+	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1743518032245</Id>

--- a/_alp/Agents/Zero_Interface/EmbeddedObjects.xml
+++ b/_alp/Agents/Zero_Interface/EmbeddedObjects.xml
@@ -139,7 +139,7 @@
 		<Id>1716193013122</Id>
 		<Name><![CDATA[uI_Results]]></Name>
 		<X>-670</X>
-		<Y>550</Y>
+		<Y>571</Y>
 		<Label>
 			<X>15</X>
 			<Y>0</Y>
@@ -268,7 +268,7 @@
 		<Id>1722252541830</Id>
 		<Name><![CDATA[uI_Tabs]]></Name>
 		<X>-670</X>
-		<Y>670</Y>
+		<Y>681</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>

--- a/_alp/Agents/Zero_Interface/Levels/Level.level.xml
+++ b/_alp/Agents/Zero_Interface/Levels/Level.level.xml
@@ -3055,7 +3055,7 @@ b_updateCongestionColors = false;
 		<Id>1702552223737</Id>
 		<Name><![CDATA[t_stylingFunctions]]></Name>
 		<X>-680</X>
-		<Y>300</Y>
+		<Y>321</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -3654,7 +3654,7 @@ van het gebied, en de huidige gasconsumptie voor verwarming.]]></Text>
 		<Id>1710174312959</Id>
 		<Name><![CDATA[t_resultsUIFunctions]]></Name>
 		<X>-680</X>
-		<Y>520</Y>
+		<Y>541</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -4838,7 +4838,7 @@ else{
 		<Id>1725456122345</Id>
 		<Name><![CDATA[txt_sliderInitialization]]></Name>
 		<X>-680</X>
-		<Y>640</Y>
+		<Y>651</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -5468,13 +5468,13 @@ else{
 		<EmbeddedIcon>false</EmbeddedIcon>
 		<Id>1740670519131</Id>
 		<Name><![CDATA[cb_EhubConfig]]></Name>
-		<X>-250</X>
-		<Y>700</Y>
+		<X>-680</X>
+		<Y>920</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
 		</Label>
-		<PublicFlag>true</PublicFlag>
+		<PublicFlag>false</PublicFlag>
 		<PresentationFlag>true</PresentationFlag>
 		<ShowLabel>false</ShowLabel>
 		<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
@@ -5482,7 +5482,7 @@ else{
 			<EmbeddedIcon>false</EmbeddedIcon>
 			<TextColor/>
 			<VisibleCode>v_customEnergyCoop != null</VisibleCode>
-			<Enabled>true</Enabled>
+			<Enabled>false</Enabled>
 			<ActionCode>if(cb_EhubConfig.isSelected()){
 	uI_Results.v_selectedChartType = OL_ChartTypes.GESPREKSLEIDRAAD_BEDRIJVEN;
 	uI_Results.f_showCorrectChart();

--- a/_alp/Agents/Zero_Interface/Variables.xml
+++ b/_alp/Agents/Zero_Interface/Variables.xml
@@ -1833,7 +1833,7 @@
 		<Id>1731425176471</Id>
 		<Name><![CDATA[b_changeToCustomScenario]]></Name>
 		<X>-670</X>
-		<Y>770</Y>
+		<Y>781</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1855,7 +1855,7 @@
 		<Id>1732027307811</Id>
 		<Name><![CDATA[b_runningMainInterfaceScenarios]]></Name>
 		<X>-670</X>
-		<Y>750</Y>
+		<Y>761</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>


### PR DESCRIPTION
Added the auto fit map bounds on startup function. So projects no longer have to manually set the map bounds by inserting coordinates and map scales in the startup agent. However, this is still possible: if they are filled, the autofit will not be performed.