### PR TITLE
PV orientation for buildings and solarfarms

### DIFF
--- a/Zero_Interface-Loader.alpx
+++ b/Zero_Interface-Loader.alpx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AnyLogicWorkspace splitVersion="1"
                    WorkspaceVersion="1.9"
-                   AnyLogicVersion="8.9.7.202512121156"
+                   AnyLogicVersion="8.9.7.202512010504"
                    AlpVersion="8.9.7">
 	<Model>
 		<Id>1658477103134</Id>

--- a/_alp/Agents/AVGC_data/Code/Functions.java
+++ b/_alp/Agents/AVGC_data/Code/Functions.java
@@ -108,7 +108,7 @@ dataAVGC.p_avgPVPower_kWpm2= p_avgPVPower_kWpm2;
 dataAVGC.p_avgRatioRoofPotentialPV = p_avgRatioRoofPotentialPV;
 dataAVGC.p_avgRatioBatteryCapacity_v_Power = p_avgRatioBatteryCapacity_v_Power;
 dataAVGC.p_avgSolarFieldPower_kWppha = p_avgSolarFieldPower_kWppha;
-
+dataAVGC.p_defaultPVOrientation = p_defaultPVOrientation;
 
 //Thermal model parameters
 dataAVGC.p_PBL_HeatingLossFactor_fr = p_PBL_HeatingLossFactor_fr;

--- a/_alp/Agents/AVGC_data/Levels/Level.level.xml
+++ b/_alp/Agents/AVGC_data/Levels/Level.level.xml
@@ -336,7 +336,7 @@
 		<Id>1726584205562</Id>
 		<Name><![CDATA[txt_avgBat]]></Name>
 		<X>510</X>
-		<Y>930</Y>
+		<Y>960</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -689,7 +689,7 @@
 		<Id>1768315329120</Id>
 		<Name><![CDATA[txt_thermalModelParameters]]></Name>
 		<X>510</X>
-		<Y>1000</Y>
+		<Y>1030</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>

--- a/_alp/Agents/AVGC_data/Variables.xml
+++ b/_alp/Agents/AVGC_data/Variables.xml
@@ -1214,7 +1214,7 @@ https://www.zonnepanelennoord.nl/vermogen-zonnepanelen/ --> 215 W/m2]]></Descrip
 		<Description><![CDATA[Average ratio of battery capacity over battery power.
 --> If battery capacity (in kWh) is twice the battery power (in kW) --> ratio = 2.]]></Description>
 		<X>520</X>
-		<Y>955</Y>
+		<Y>985</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2273,7 +2273,7 @@ Voor nu gekozen voor 4185.
 		<Name><![CDATA[p_avgRatioHouseBatteryStorageCapacity_v_PVPower]]></Name>
 		<Description><![CDATA[https://www.essent.nl/thuisbatterij/capaciteit-thuisbatterij : Essent: "Over het algemeen kun je ervan uitgaan dat een thuisbatterij zo'n 1 à 1,5 kWh capaciteit nodig heeft per kWp zonnepanelen vermogen. " ]]></Description>
 		<X>520</X>
-		<Y>975</Y>
+		<Y>1005</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2603,7 +2603,7 @@ https://warmtepomp-panel.nl/afgiftesysteem.html? -> 35 graden afgifte bij -10 gr
 		<Name><![CDATA[p_PBL_HeatingLossFactor_fr]]></Name>
 		<Description><![CDATA[Manually calibrated value tested on 3 neighborhoods to get the total nbh yearly total to match with the expected outcome.]]></Description>
 		<X>520</X>
-		<Y>1030</Y>
+		<Y>1060</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2631,7 +2631,7 @@ https://warmtepomp-panel.nl/afgiftesysteem.html? -> 35 graden afgifte bij -10 gr
 		<Id>1768314112512</Id>
 		<Name><![CDATA[map_insulationLabel_lossfactorPerFloorSurface_WpKm2]]></Name>
 		<X>520</X>
-		<Y>1050</Y>
+		<Y>1080</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2669,7 +2669,7 @@ OL_GridConnectionInsulationLabel.G, 1.45
 		<Name><![CDATA[p_solarAbsorptionFloorSurfaceScalingFactor_fr]]></Name>
 		<Description><![CDATA[Roughly aligned with data-analysis/fitting by Zin Li (TU/e PhD) based on measured data of 100 houses in Dalenm during DACS-HW project. Increased by a factor ~2 after manual testing/calibration by Gillis and Naud.]]></Description>
 		<X>520</X>
-		<Y>1070</Y>
+		<Y>1100</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2781,7 +2781,7 @@ OL_GridConnectionInsulationLabel.G, 1.45
 		<Id>1768497744964</Id>
 		<Name><![CDATA[p_heatCapacitySizingConstant_JpK]]></Name>
 		<X>520</X>
-		<Y>1120</Y>
+		<Y>1150</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2809,7 +2809,7 @@ OL_GridConnectionInsulationLabel.G, 1.45
 		<Id>1768497744970</Id>
 		<Name><![CDATA[p_heatCapacitySizingSlope_JpKm2]]></Name>
 		<X>520</X>
-		<Y>1140</Y>
+		<Y>1170</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2838,7 +2838,7 @@ OL_GridConnectionInsulationLabel.G, 1.45
 		<Id>1768497744974</Id>
 		<Name><![CDATA[p_heatCapacitySizingFactor_fr]]></Name>
 		<X>520</X>
-		<Y>1160</Y>
+		<Y>1190</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2926,7 +2926,7 @@ The cooldown period is defined as the duration of time before a building  is coo
 
 FIND SOURCE AND CORRECT THE NUMBERS BEFORE USE!]]></Description>
 		<X>520</X>
-		<Y>1100</Y>
+		<Y>1130</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2967,7 +2967,7 @@ OL_GridConnectionInsulationLabel.G, 4.0
 		<Description><![CDATA[Cooldown timescale as approximately 'measured' on an energy label A, free-standing, wooden house. Modern, terraced and stone houses might have longer cooldown timescale. (meaning it can more effectively buffer heat)]]></Description>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>520</X>
-		<Y>1210</Y>
+		<Y>1240</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -3040,6 +3040,34 @@ OL_GridConnectionInsulationLabel.G, 4.0
 			</DefaultValue>
 			<ParameterEditor>
 				<Id>1772188856700</Id>
+				<EditorContolType>TEXT_BOX</EditorContolType>
+				<MinSliderValue>0</MinSliderValue>
+				<MaxSliderValue>100</MaxSliderValue>
+				<DelimeterType>NO_DELIMETER</DelimeterType>
+			</ParameterEditor>
+		</Properties>
+	</Variable>
+	<Variable Class="Parameter">
+		<Id>1775122631307</Id>
+		<Name><![CDATA[p_defaultPVOrientation]]></Name>
+		<X>520</X>
+		<Y>935</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true" ModificatorType="STATIC">
+			<Type><![CDATA[OL_PVOrientation]]></Type>
+			<UnitType>NONE</UnitType>
+			<SdArray>false</SdArray>
+			<DefaultValue Class="CodeValue">
+				<Code><![CDATA[OL_PVOrientation.SOUTH]]></Code>
+			</DefaultValue>
+			<ParameterEditor>
+				<Id>1775122631305</Id>
 				<EditorContolType>TEXT_BOX</EditorContolType>
 				<MinSliderValue>0</MinSliderValue>
 				<MaxSliderValue>100</MaxSliderValue>

--- a/_alp/Agents/Zero_Loader/AOC.Zero_Loader.xml
+++ b/_alp/Agents/Zero_Loader/AOC.Zero_Loader.xml
@@ -54,7 +54,8 @@ import com.querydsl.core.types.dsl.CaseBuilder;
 import energy.lux.uplux.*;
 //import java.util.UUID;
 import kotlin.uuid.Uuid;
-import org.eclipse.jetty.server.LowResourceMonitor.MaxConnectionsLowResourceCheck;]]></Import>
+import org.eclipse.jetty.server.LowResourceMonitor.MaxConnectionsLowResourceCheck;
+import com.zenmo.zummon.companysurvey.PVOrientation;]]></Import>
 	<Generic>false</Generic>
 	<GenericParameter>
 		<Id>1726584205730</Id>

--- a/_alp/Agents/Zero_Loader/Code/Functions.java
+++ b/_alp/Agents/Zero_Loader/Code/Functions.java
@@ -2139,7 +2139,7 @@ double[] a_normalizedPower_fr = Arrays.stream(yearlyElectricityProduction_kWh).m
 //J_ProfilePointer profilePointer = new J_ProfilePointer((parentGC.p_ownerID + "_PVproduction") , tf_customPVproduction_fr, OL_ProfileUnits.NORMALIZEDPOWER);
 double dataTimeStep_h = 0.25;
 double dataStartTime_h = 0.0;
-J_ProfilePointer profilePointer = new J_ProfilePointer((parentGC.p_ownerID + "_PVproduction") , a_normalizedPower_fr, dataTimeStep_h, dataStartTime_h, OL_ProfileUnits.NORMALIZEDPOWER);
+J_ProfilePointer profilePointer = new J_ProfilePointer(("GC: " + parentGC.p_gridConnectionID + " custom pv profile") , a_normalizedPower_fr, dataTimeStep_h, dataStartTime_h, OL_ProfileUnits.NORMALIZEDPOWER);
 energyModel.f_addProfile(profilePointer);
 J_EAProduction production_asset = new J_EAProduction(parentGC, OL_EnergyAssetType.PHOTOVOLTAIC, (parentGC.p_ownerID + "_rooftopPV"), OL_EnergyCarriers.ELECTRICITY, (double)pvPower_kW, energyModel.p_timeParameters, profilePointer);
 

--- a/_alp/Agents/Zero_Loader/Code/Functions.java
+++ b/_alp/Agents/Zero_Loader/Code/Functions.java
@@ -3563,9 +3563,10 @@ for (Building_data houseBuildingData : buildingDataHouses) {
 	//Set PV information
 	GCH.v_liveAssetsMetaData.initialPV_kW = houseBuildingData.pv_installed_kwp() != null ? houseBuildingData.pv_installed_kwp() : 0;
 	GCH.v_liveAssetsMetaData.PVPotential_kW = GCH.v_liveAssetsMetaData.initialPV_kW > 0 ? GCH.v_liveAssetsMetaData.initialPV_kW : houseBuildingData.pv_potential_kwp(); // To prevent sliders from changing outcomes
-
+	GCH.v_liveAssetsMetaData.PVOrientation = houseBuildingData.pv_orientation() != null ? houseBuildingData.pv_orientation() : avgc_data.p_defaultPVOrientation;
+	
 	//Create and add EnergyAssets
-	f_addEnergyAssetsToHouses(GCH, houseBuildingData.electricity_consumption_kwhpa(), houseBuildingData.gas_consumption_m3pa(), houseBuildingData.heating_type(), houseBuildingData.cooking_type(), houseBuildingData.pv_orientation());
+	f_addEnergyAssetsToHouses(GCH, houseBuildingData.electricity_consumption_kwhpa(), houseBuildingData.gas_consumption_m3pa(), houseBuildingData.heating_type(), houseBuildingData.cooking_type());
 	
 	i++;
 }
@@ -3580,7 +3581,7 @@ for(GCHouse GCH : energyModel.Houses){
 //traceln("Total space heat demand houses input " + roundToDecimal(totalSpaceHeatDemand_kwhpa/1000000,3) + "GWh");
 /*ALCODEEND*/}
 
-double f_addEnergyAssetsToHouses(GCHouse house,Double electricityDemand_kwhpa,Double gasDemand_m3pa,OL_GridConnectionHeatingType heatingType,OL_HouseholdCookingMethod cookingType,OL_PVOrientation pvOrientation)
+double f_addEnergyAssetsToHouses(GCHouse house,Double electricityDemand_kwhpa,Double gasDemand_m3pa,OL_GridConnectionHeatingType heatingType,OL_HouseholdCookingMethod cookingType)
 {/*ALCODESTART::1749728889986*/
 //Add generic electricity demand profile 
 GridNode gn = findFirst(energyModel.pop_gridNodes, x -> x.p_gridNodeID.equals( house.p_parentNodeElectricID));
@@ -3599,7 +3600,7 @@ f_addHeatAssetsToHouses(house, gasDemand_m3pa, heatingType, cookingType);
 
 
 //Add pv
-f_addPVToHouses(house, gn, pvOrientation);
+f_addPVToHouses(house, gn);
 
 //Add cars
 f_addCarsToHouses(house);
@@ -5212,9 +5213,10 @@ for (Windfarm_data windpark : c_windfarm_data){
 return totalPVPower_kW;
 /*ALCODEEND*/}
 
-double f_addPVToHouses(GCHouse house,GridNode gn,OL_PVOrientation pvOrientation)
+double f_addPVToHouses(GCHouse house,GridNode gn)
 {/*ALCODESTART::1770037586816*/
 double installedRooftopSolar_kW = house.v_liveAssetsMetaData.initialPV_kW != null ? house.v_liveAssetsMetaData.initialPV_kW : 0;
+OL_PVOrientation pvOrientation = house.v_liveAssetsMetaData.PVOrientation;
 
 if (gn.p_profileType == OL_GridNodeProfileLoaderType.INCLUDE_PV || gn.p_profileType == OL_GridNodeProfileLoaderType.NET_LOAD){ //dont count production if there is measured data on Node
 	installedRooftopSolar_kW = 0;
@@ -5222,7 +5224,6 @@ if (gn.p_profileType == OL_GridNodeProfileLoaderType.INCLUDE_PV || gn.p_profileT
 
 if (installedRooftopSolar_kW > 0) {
 	f_addPVProductionAsset(house, "Residential Solar", installedRooftopSolar_kW, pvOrientation);
-	//f_addEnergyProduction(house, OL_EnergyAssetType.PHOTOVOLTAIC, "Residential Solar", installedRooftopSolar_kW);
 }
 /*ALCODEEND*/}
 
@@ -5278,7 +5279,7 @@ OL_PVOrientation pvOrientation = avgc_data.p_defaultPVOrientation;
 if(PVOrientationZorm != null){
 	switch(PVOrientationZorm){
 		case SOUTH:
-			pvOrientation = OL_PVOrientation.EASTWEST;
+			pvOrientation = OL_PVOrientation.SOUTH;
 			break;
 		case EAST_WEST:
 			pvOrientation = OL_PVOrientation.EASTWEST;

--- a/_alp/Agents/Zero_Loader/Code/Functions.java
+++ b/_alp/Agents/Zero_Loader/Code/Functions.java
@@ -1017,38 +1017,6 @@ for (Parcel_data dataParcel : c_parcel_data) {
 }
 /*ALCODEEND*/}
 
-double f_addEnergyProduction(GridConnection parentGC,OL_EnergyAssetType asset_type,String asset_name,double installedPower_kW)
-{/*ALCODESTART::1726584205809*/
-double assetCapacity_kW = 0;
-J_TimeParameters timeParameters = energyModel.p_timeParameters;
-J_ProfilePointer profilePointer = null;
-OL_EnergyCarriers energyCarrier = OL_EnergyCarriers.ELECTRICITY;
-switch (asset_type){
-
-case PHOTOVOLTAIC: 
-	energyCarrier = OL_EnergyCarriers.ELECTRICITY;
-	profilePointer = energyModel.pp_PVProduction35DegSouth_fr;
-	assetCapacity_kW = installedPower_kW;
-	break;
-
-case WINDMILL:
-	energyCarrier = OL_EnergyCarriers.ELECTRICITY;
-	profilePointer=energyModel.pp_windProduction_fr;
-	assetCapacity_kW = installedPower_kW;
-	break;
-
-case PHOTOTHERMAL: //NOT USED YET
-	energyCarrier = OL_EnergyCarriers.HEAT;
-	profilePointer = energyModel.pp_PVProduction35DegSouth_fr; // Voor nu om te testen! Misschien valt dit wel te gebruiken met bepaalde efficientie factor!
-	assetCapacity_kW = installedPower_kW;
-	break;
-}
-
-J_EAProduction production_asset = new J_EAProduction(parentGC, asset_type, asset_name, energyCarrier, assetCapacity_kW, timeParameters, profilePointer);
-
-
-/*ALCODEEND*/}
-
 GIS_Object f_createGISObject(String name,double latitude,double longitude,String polygon,OL_GISObjectType GISObjectType)
 {/*ALCODESTART::1726584205811*/
 GIS_Object area = energyModel.add_pop_GIS_Objects();

--- a/_alp/Agents/Zero_Loader/Code/Functions.java
+++ b/_alp/Agents/Zero_Loader/Code/Functions.java
@@ -304,7 +304,8 @@ for (Solarfarm_data dataSolarfarm : f_getSolarfarmsInSubScope(c_solarfarm_data))
 			} 
 		}
 		if(gridNodeProfileLoaderType != OL_GridNodeProfileLoaderType.INCLUDE_PV || gridNodeProfileLoaderType != OL_GridNodeProfileLoaderType.NET_LOAD){
-			f_addEnergyProduction(solarpark, OL_EnergyAssetType.PHOTOVOLTAIC, "Solar farm" , dataSolarfarm.capacity_electric_kw());
+			f_addPVProductionAsset(solarpark, "Solar farm" , dataSolarfarm.capacity_electric_kw(), dataSolarfarm.orientation(), dataSolarfarm.tilt_angle_deg());
+			//f_addEnergyProduction(solarpark, OL_EnergyAssetType.PHOTOVOLTAIC, "Solar farm" , dataSolarfarm.capacity_electric_kw());
 		}
 		
 		//Set owner
@@ -611,7 +612,8 @@ for (Windfarm_data dataWindfarm : f_getWindfarmsInSubScope(c_windfarm_data)) {
 		windfarm.v_isActive = dataWindfarm.initially_active();
 		
 		//Create EA for the windturbine GC
-		f_addEnergyProduction(windfarm, OL_EnergyAssetType.WINDMILL, "Windmill onshore", dataWindfarm.capacity_electric_kw());
+		f_addWindProductionAsset(windfarm, "Windmill onshore", dataWindfarm.capacity_electric_kw());
+		//f_addEnergyProduction(windfarm, OL_EnergyAssetType.WINDMILL, "Windmill onshore", dataWindfarm.capacity_electric_kw());
 		
 		//Set owner
 		ConnectionOwner owner;
@@ -1018,7 +1020,7 @@ for (Parcel_data dataParcel : c_parcel_data) {
 
 double f_addEnergyProduction(GridConnection parentGC,OL_EnergyAssetType asset_type,String asset_name,double installedPower_kW)
 {/*ALCODESTART::1726584205809*/
-double assetCapacity_kW				= 0;
+double assetCapacity_kW = 0;
 J_TimeParameters timeParameters = energyModel.p_timeParameters;
 J_ProfilePointer profilePointer = null;
 OL_EnergyCarriers energyCarrier = OL_EnergyCarriers.ELECTRICITY;
@@ -1529,7 +1531,8 @@ if (gridNodeProfileLoaderType == OL_GridNodeProfileLoaderType.INCLUDE_PV || grid
 	pv_installed_kwp = 0.0;
 }
 if(pv_installed_kwp != null && pv_installed_kwp > 0){
-	f_addEnergyProduction(companyGC, OL_EnergyAssetType.PHOTOVOLTAIC, "Rooftop Solar", pv_installed_kwp);
+	f_addPVProductionAsset(companyGC, "Rooftop Solar", pv_installed_kwp, OL_Orientation.SOUTH, 35.0);
+	//f_addEnergyProduction(companyGC, OL_EnergyAssetType.PHOTOVOLTAIC, "Rooftop Solar", pv_installed_kwp);
 	
 	current_scenario_list.setCurrentPV_kW(roundToInt(pv_installed_kwp));
 	future_scenario_list.setPlannedPV_kW(roundToInt(pv_installed_kwp));
@@ -2367,7 +2370,8 @@ if (gridConnection.getSupply().getHasSupply() != null && gridConnection.getSuppl
 		current_scenario_list.setCurrentPV_kW(gridConnection.getSupply().getPvInstalledKwp());
 	} else if (gridConnection.getSupply().getPvInstalledKwp() != null && gridConnection.getSupply().getPvInstalledKwp() > 0){			
 		//gridConnection.getSupply().getPvOrientation(); // Wat doen we hier mee????? Nog niets!
-		f_addEnergyProduction(companyGC, OL_EnergyAssetType.PHOTOVOLTAIC, "Rooftop Solar", gridConnection.getSupply().getPvInstalledKwp());
+		f_addPVProductionAsset(companyGC, "Rooftop Solar", (double) gridConnection.getSupply().getPvInstalledKwp(), OL_Orientation.SOUTH, 35.0); //NEEDS FIXING
+		//f_addEnergyProduction(companyGC, OL_EnergyAssetType.PHOTOVOLTAIC, "Rooftop Solar", gridConnection.getSupply().getPvInstalledKwp());
 		
 		//add to scenario: current
 		current_scenario_list.setCurrentPV_kW(gridConnection.getSupply().getPvInstalledKwp());
@@ -2375,7 +2379,8 @@ if (gridConnection.getSupply().getHasSupply() != null && gridConnection.getSuppl
 	} 	
 	//Wind
 	if (gridConnection.getSupply().getWindInstalledKw() != null && gridConnection.getSupply().getWindInstalledKw() > 0){
-		f_addEnergyProduction(companyGC, OL_EnergyAssetType.WINDMILL, "Wind mill", gridConnection.getSupply().getWindInstalledKw());
+		f_addWindProductionAsset(companyGC, "Wind mill", gridConnection.getSupply().getWindInstalledKw());
+		//f_addEnergyProduction(companyGC, OL_EnergyAssetType.WINDMILL, "Wind mill", gridConnection.getSupply().getWindInstalledKw());
 
 		//add to scenario: current
 		current_scenario_list.setCurrentWind_kW(gridConnection.getSupply().getWindInstalledKw());
@@ -3256,7 +3261,8 @@ else { //INCLUDE_PV or EXCLUDE_PV
 			pvPower_kW = 2.5 * (maxFeedin_kWh/energyModel.p_timeParameters.getTimeStep_h()); // Estimation needed for pv power
 			traceln("PV Power has been estimated!");
 			f_createPreprocessedElectricityProfile_PV(GC_GridNode_profile, a_yearlyElectricityDelivery_kWh, a_yearlyElectricityFeedin_kWh, null, pvPower_kW, null);
-			f_addEnergyProduction(GC_GridNode_profile, OL_EnergyAssetType.PHOTOVOLTAIC, "Total current Solar on GridNode", pvPower_kW);
+			f_addPVProductionAsset(GC_GridNode_profile, "Total current Solar on GridNode", pvPower_kW, OL_Orientation.SOUTH, 35.0);
+			//f_addEnergyProduction(GC_GridNode_profile, OL_EnergyAssetType.PHOTOVOLTAIC, "Total current Solar on GridNode", pvPower_kW);
 		}
 		else { //EXCLUDE_PV
 			throw new RuntimeException("Grid node profile contains feed-in but no PV power is found in Building_data for EXCLUDE_PV. This is not allowed.");
@@ -3268,7 +3274,8 @@ else { //INCLUDE_PV or EXCLUDE_PV
 		}
 		f_createPreprocessedElectricityProfile_PV(GC_GridNode_profile, a_yearlyElectricityDelivery_kWh, a_yearlyElectricityFeedin_kWh, null, pvPower_kW, null);
 		if (gridnode.p_profileType == OL_GridNodeProfileLoaderType.INCLUDE_PV){
-			f_addEnergyProduction(GC_GridNode_profile, OL_EnergyAssetType.PHOTOVOLTAIC, "Total current Solar on GridNode", pvPower_kW);
+			f_addPVProductionAsset(GC_GridNode_profile, "Total current Solar on GridNode", pvPower_kW, OL_Orientation.SOUTH, 35.0);
+			//f_addEnergyProduction(GC_GridNode_profile, OL_EnergyAssetType.PHOTOVOLTAIC, "Total current Solar on GridNode", pvPower_kW);
 		}
 	}
 }
@@ -3569,7 +3576,7 @@ for (Building_data houseBuildingData : buildingDataHouses) {
 	GCH.v_liveAssetsMetaData.PVPotential_kW = GCH.v_liveAssetsMetaData.initialPV_kW > 0 ? GCH.v_liveAssetsMetaData.initialPV_kW : houseBuildingData.pv_potential_kwp(); // To prevent sliders from changing outcomes
 
 	//Create and add EnergyAssets
-	f_addEnergyAssetsToHouses(GCH, houseBuildingData.electricity_consumption_kwhpa(), houseBuildingData.gas_consumption_m3pa(), houseBuildingData.heating_type(), houseBuildingData.cooking_type());
+	f_addEnergyAssetsToHouses(GCH, houseBuildingData.electricity_consumption_kwhpa(), houseBuildingData.gas_consumption_m3pa(), houseBuildingData.heating_type(), houseBuildingData.cooking_type(), houseBuildingData.roof_orientation(), houseBuildingData.roof_pitch_deg());
 	
 	i++;
 }
@@ -3584,7 +3591,7 @@ for(GCHouse GCH : energyModel.Houses){
 //traceln("Total space heat demand houses input " + roundToDecimal(totalSpaceHeatDemand_kwhpa/1000000,3) + "GWh");
 /*ALCODEEND*/}
 
-double f_addEnergyAssetsToHouses(GCHouse house,Double electricityDemand_kwhpa,Double gasDemand_m3pa,OL_GridConnectionHeatingType heatingType,OL_HouseholdCookingMethod cookingType)
+double f_addEnergyAssetsToHouses(GCHouse house,Double electricityDemand_kwhpa,Double gasDemand_m3pa,OL_GridConnectionHeatingType heatingType,OL_HouseholdCookingMethod cookingType,OL_Orientation orientation,double roofPitch_deg)
 {/*ALCODESTART::1749728889986*/
 //Add generic electricity demand profile 
 GridNode gn = findFirst(energyModel.pop_gridNodes, x -> x.p_gridNodeID.equals( house.p_parentNodeElectricID));
@@ -3603,7 +3610,7 @@ f_addHeatAssetsToHouses(house, gasDemand_m3pa, heatingType, cookingType);
 
 
 //Add pv
-f_addPVToHouses(house, gn);
+f_addPVToHouses(house, gn, orientation, roofPitch_deg);
 
 //Add cars
 f_addCarsToHouses(house);
@@ -5216,7 +5223,7 @@ for (Windfarm_data windpark : c_windfarm_data){
 return totalPVPower_kW;
 /*ALCODEEND*/}
 
-double f_addPVToHouses(GCHouse house,GridNode gn)
+double f_addPVToHouses(GCHouse house,GridNode gn,OL_Orientation orientation,double roofPitch_deg)
 {/*ALCODESTART::1770037586816*/
 double installedRooftopSolar_kW = house.v_liveAssetsMetaData.initialPV_kW != null ? house.v_liveAssetsMetaData.initialPV_kW : 0;
 
@@ -5225,7 +5232,60 @@ if (gn.p_profileType == OL_GridNodeProfileLoaderType.INCLUDE_PV || gn.p_profileT
 }
 
 if (installedRooftopSolar_kW > 0) {
-	f_addEnergyProduction(house, OL_EnergyAssetType.PHOTOVOLTAIC, "Residential Solar", installedRooftopSolar_kW );
+	f_addPVProductionAsset(house, "Residential Solar", installedRooftopSolar_kW, orientation, roofPitch_deg);
+	//f_addEnergyProduction(house, OL_EnergyAssetType.PHOTOVOLTAIC, "Residential Solar", installedRooftopSolar_kW);
 }
+/*ALCODEEND*/}
+
+double f_addPVProductionAsset(GridConnection parentGC,String asset_name,double installedPower_kW,OL_Orientation orientation,double roofPitch_deg)
+{/*ALCODESTART::1773414911038*/
+J_TimeParameters timeParameters = energyModel.p_timeParameters;
+OL_EnergyCarriers energyCarrier = OL_EnergyCarriers.ELECTRICITY;
+J_ProfilePointer profilePointer = f_determinePVTProfilePointer(orientation, roofPitch_deg);
+
+J_EAProduction production_asset = new J_EAProduction(parentGC, OL_EnergyAssetType.PHOTOVOLTAIC, asset_name, energyCarrier, installedPower_kW, timeParameters, profilePointer);
+/*ALCODEEND*/}
+
+J_ProfilePointer f_determinePVTProfilePointer(OL_Orientation orientation,double roofPitch_deg)
+{/*ALCODESTART::1773414911040*/
+J_ProfilePointer profilePointer = null;
+
+switch (orientation){
+	case EASTWEST:
+		if (roofPitch_deg <= 15 && roofPitch_deg >= 0){
+			profilePointer = energyModel.pp_PVProduction15DegEastWest_fr;
+		}
+		else {
+			throw new RuntimeException("ProfilePointer for a combination of " + orientation + " and " + roofPitch_deg + " is not supported (yet)!");
+		}
+	case SOUTH:
+		if (roofPitch_deg <= 35 && roofPitch_deg >= 0){
+			profilePointer = energyModel.pp_PVProduction35DegSouth_fr;
+		}
+		else {
+			throw new RuntimeException("ProfilePointer for a combination of " + orientation + " and " + roofPitch_deg + " is not supported (yet)!");
+		}
+}
+
+return profilePointer;
+/*ALCODEEND*/}
+
+double f_addWindProductionAsset(GridConnection parentGC,String asset_name,double installedPower_kW)
+{/*ALCODESTART::1773414911042*/
+J_TimeParameters timeParameters = energyModel.p_timeParameters;
+OL_EnergyCarriers energyCarrier = OL_EnergyCarriers.ELECTRICITY;
+J_ProfilePointer profilePointer = energyModel.pp_windProduction_fr;
+
+J_EAProduction production_asset = new J_EAProduction(parentGC, OL_EnergyAssetType.WINDMILL, asset_name, energyCarrier, installedPower_kW, timeParameters, profilePointer);
+/*ALCODEEND*/}
+
+double f_addPTProductionAsset(GridConnection parentGC,String asset_name,double installedPower_kW,OL_Orientation orientation,int roofPitch_deg)
+{/*ALCODESTART::1773414911044*/
+//CONCEPT VERSION
+J_TimeParameters timeParameters = energyModel.p_timeParameters;
+OL_EnergyCarriers energyCarrier = OL_EnergyCarriers.HEAT;
+J_ProfilePointer profilePointer = f_determinePVTProfilePointer(orientation, roofPitch_deg);
+
+J_EAProduction production_asset = new J_EAProduction(parentGC, OL_EnergyAssetType.PHOTOVOLTAIC, asset_name, energyCarrier, installedPower_kW, timeParameters, profilePointer);
 /*ALCODEEND*/}
 

--- a/_alp/Agents/Zero_Loader/Code/Functions.java
+++ b/_alp/Agents/Zero_Loader/Code/Functions.java
@@ -260,7 +260,6 @@ for (Solarfarm_data dataSolarfarm : f_getSolarfarmsInSubScope(c_solarfarm_data))
 		solarpark = energyModel.add_EnergyProductionSites();
 		
 		solarpark.set_p_gridConnectionID( dataSolarfarm.gc_id() );
-		
 		//Set Address
 		solarpark.p_address = new J_Address(dataSolarfarm.streetname(), 
 											dataSolarfarm.house_number(), 
@@ -304,7 +303,7 @@ for (Solarfarm_data dataSolarfarm : f_getSolarfarmsInSubScope(c_solarfarm_data))
 			} 
 		}
 		if(gridNodeProfileLoaderType != OL_GridNodeProfileLoaderType.INCLUDE_PV || gridNodeProfileLoaderType != OL_GridNodeProfileLoaderType.NET_LOAD){
-			f_addPVProductionAsset(solarpark, "Solar farm" , dataSolarfarm.capacity_electric_kw(), dataSolarfarm.orientation(), dataSolarfarm.tilt_angle_deg());
+			f_addPVProductionAsset(solarpark, "Solar farm" , dataSolarfarm.capacity_electric_kw(), dataSolarfarm.orientation());
 			//f_addEnergyProduction(solarpark, OL_EnergyAssetType.PHOTOVOLTAIC, "Solar farm" , dataSolarfarm.capacity_electric_kw());
 		}
 		
@@ -1531,7 +1530,7 @@ if (gridNodeProfileLoaderType == OL_GridNodeProfileLoaderType.INCLUDE_PV || grid
 	pv_installed_kwp = 0.0;
 }
 if(pv_installed_kwp != null && pv_installed_kwp > 0){
-	f_addPVProductionAsset(companyGC, "Rooftop Solar", pv_installed_kwp, OL_Orientation.SOUTH, 35.0);
+	f_addPVProductionAsset(companyGC, "Rooftop Solar", pv_installed_kwp, OL_PVOrientation.SOUTH);
 	//f_addEnergyProduction(companyGC, OL_EnergyAssetType.PHOTOVOLTAIC, "Rooftop Solar", pv_installed_kwp);
 	
 	current_scenario_list.setCurrentPV_kW(roundToInt(pv_installed_kwp));
@@ -2370,7 +2369,7 @@ if (gridConnection.getSupply().getHasSupply() != null && gridConnection.getSuppl
 		current_scenario_list.setCurrentPV_kW(gridConnection.getSupply().getPvInstalledKwp());
 	} else if (gridConnection.getSupply().getPvInstalledKwp() != null && gridConnection.getSupply().getPvInstalledKwp() > 0){			
 		//gridConnection.getSupply().getPvOrientation(); // Wat doen we hier mee????? Nog niets!
-		f_addPVProductionAsset(companyGC, "Rooftop Solar", (double) gridConnection.getSupply().getPvInstalledKwp(), OL_Orientation.SOUTH, 35.0); //NEEDS FIXING
+		f_addPVProductionAsset(companyGC, "Rooftop Solar", (double) gridConnection.getSupply().getPvInstalledKwp(), OL_PVOrientation.SOUTH); //NEEDS FIXING
 		//f_addEnergyProduction(companyGC, OL_EnergyAssetType.PHOTOVOLTAIC, "Rooftop Solar", gridConnection.getSupply().getPvInstalledKwp());
 		
 		//add to scenario: current
@@ -2986,6 +2985,8 @@ city(null).
 gridnode_id(gridNodeID).
 initially_active(false).
 
+orientation(OL_PVOrientation.SOUTH).
+
 capacity_electric_kw(0.0).
 connection_capacity_kw(0.0).
 contracted_delivery_capacity_kw(0.0).
@@ -3148,8 +3149,8 @@ double[] a_defaultBuildingHeatDemandProfile_fr = ListUtil.doubleListToArray(defa
 
 //Create Weather engine profiles
 energyModel.pp_ambientTemperature_degC = f_createEngineProfile("ambient_temperature_degC", a_arguments_hr, a_ambientTemperatureProfile_degC, OL_ProfileUnits.TEMPERATURE_DEGC);
-energyModel.pp_PVProduction35DegSouth_fr = f_createEngineProfile("pv_production_south_fr", a_arguments_hr, a_PVProductionProfile35DegSouth_fr, OL_ProfileUnits.NORMALIZEDPOWER);
-energyModel.pp_PVProduction15DegEastWest_fr = f_createEngineProfile("pv_production_eastwest_fr", a_arguments_hr, a_PVProductionProfile15DegEastWest_fr, OL_ProfileUnits.NORMALIZEDPOWER);
+energyModel.pp_PVProduction35DegSouth_fr = f_createEngineProfile("pv_production_35degsouth_fr", a_arguments_hr, a_PVProductionProfile35DegSouth_fr, OL_ProfileUnits.NORMALIZEDPOWER);
+energyModel.pp_PVProduction15DegEastWest_fr = f_createEngineProfile("pv_production_15degeastwest_fr", a_arguments_hr, a_PVProductionProfile15DegEastWest_fr, OL_ProfileUnits.NORMALIZEDPOWER);
 energyModel.pp_windProduction_fr = f_createEngineProfile("wind_production_fr", a_arguments_hr, a_windProductionProfile_fr, OL_ProfileUnits.NORMALIZEDPOWER);
 
 //Create Epex engine profile
@@ -3261,7 +3262,7 @@ else { //INCLUDE_PV or EXCLUDE_PV
 			pvPower_kW = 2.5 * (maxFeedin_kWh/energyModel.p_timeParameters.getTimeStep_h()); // Estimation needed for pv power
 			traceln("PV Power has been estimated!");
 			f_createPreprocessedElectricityProfile_PV(GC_GridNode_profile, a_yearlyElectricityDelivery_kWh, a_yearlyElectricityFeedin_kWh, null, pvPower_kW, null);
-			f_addPVProductionAsset(GC_GridNode_profile, "Total current Solar on GridNode", pvPower_kW, OL_Orientation.SOUTH, 35.0);
+			f_addPVProductionAsset(GC_GridNode_profile, "Total current Solar on GridNode", pvPower_kW, OL_PVOrientation.SOUTH);
 			//f_addEnergyProduction(GC_GridNode_profile, OL_EnergyAssetType.PHOTOVOLTAIC, "Total current Solar on GridNode", pvPower_kW);
 		}
 		else { //EXCLUDE_PV
@@ -3274,7 +3275,7 @@ else { //INCLUDE_PV or EXCLUDE_PV
 		}
 		f_createPreprocessedElectricityProfile_PV(GC_GridNode_profile, a_yearlyElectricityDelivery_kWh, a_yearlyElectricityFeedin_kWh, null, pvPower_kW, null);
 		if (gridnode.p_profileType == OL_GridNodeProfileLoaderType.INCLUDE_PV){
-			f_addPVProductionAsset(GC_GridNode_profile, "Total current Solar on GridNode", pvPower_kW, OL_Orientation.SOUTH, 35.0);
+			f_addPVProductionAsset(GC_GridNode_profile, "Total current Solar on GridNode", pvPower_kW, OL_PVOrientation.SOUTH);
 			//f_addEnergyProduction(GC_GridNode_profile, OL_EnergyAssetType.PHOTOVOLTAIC, "Total current Solar on GridNode", pvPower_kW);
 		}
 	}
@@ -3576,7 +3577,7 @@ for (Building_data houseBuildingData : buildingDataHouses) {
 	GCH.v_liveAssetsMetaData.PVPotential_kW = GCH.v_liveAssetsMetaData.initialPV_kW > 0 ? GCH.v_liveAssetsMetaData.initialPV_kW : houseBuildingData.pv_potential_kwp(); // To prevent sliders from changing outcomes
 
 	//Create and add EnergyAssets
-	f_addEnergyAssetsToHouses(GCH, houseBuildingData.electricity_consumption_kwhpa(), houseBuildingData.gas_consumption_m3pa(), houseBuildingData.heating_type(), houseBuildingData.cooking_type(), houseBuildingData.roof_orientation(), houseBuildingData.roof_pitch_deg());
+	f_addEnergyAssetsToHouses(GCH, houseBuildingData.electricity_consumption_kwhpa(), houseBuildingData.gas_consumption_m3pa(), houseBuildingData.heating_type(), houseBuildingData.cooking_type(), houseBuildingData.pv_orientation());
 	
 	i++;
 }
@@ -3591,7 +3592,7 @@ for(GCHouse GCH : energyModel.Houses){
 //traceln("Total space heat demand houses input " + roundToDecimal(totalSpaceHeatDemand_kwhpa/1000000,3) + "GWh");
 /*ALCODEEND*/}
 
-double f_addEnergyAssetsToHouses(GCHouse house,Double electricityDemand_kwhpa,Double gasDemand_m3pa,OL_GridConnectionHeatingType heatingType,OL_HouseholdCookingMethod cookingType,OL_Orientation orientation,double roofPitch_deg)
+double f_addEnergyAssetsToHouses(GCHouse house,Double electricityDemand_kwhpa,Double gasDemand_m3pa,OL_GridConnectionHeatingType heatingType,OL_HouseholdCookingMethod cookingType,OL_PVOrientation pvOrientation)
 {/*ALCODESTART::1749728889986*/
 //Add generic electricity demand profile 
 GridNode gn = findFirst(energyModel.pop_gridNodes, x -> x.p_gridNodeID.equals( house.p_parentNodeElectricID));
@@ -3610,7 +3611,7 @@ f_addHeatAssetsToHouses(house, gasDemand_m3pa, heatingType, cookingType);
 
 
 //Add pv
-f_addPVToHouses(house, gn, orientation, roofPitch_deg);
+f_addPVToHouses(house, gn, pvOrientation);
 
 //Add cars
 f_addCarsToHouses(house);
@@ -5223,7 +5224,7 @@ for (Windfarm_data windpark : c_windfarm_data){
 return totalPVPower_kW;
 /*ALCODEEND*/}
 
-double f_addPVToHouses(GCHouse house,GridNode gn,OL_Orientation orientation,double roofPitch_deg)
+double f_addPVToHouses(GCHouse house,GridNode gn,OL_PVOrientation pvOrientation)
 {/*ALCODESTART::1770037586816*/
 double installedRooftopSolar_kW = house.v_liveAssetsMetaData.initialPV_kW != null ? house.v_liveAssetsMetaData.initialPV_kW : 0;
 
@@ -5232,39 +5233,29 @@ if (gn.p_profileType == OL_GridNodeProfileLoaderType.INCLUDE_PV || gn.p_profileT
 }
 
 if (installedRooftopSolar_kW > 0) {
-	f_addPVProductionAsset(house, "Residential Solar", installedRooftopSolar_kW, orientation, roofPitch_deg);
+	f_addPVProductionAsset(house, "Residential Solar", installedRooftopSolar_kW, pvOrientation);
 	//f_addEnergyProduction(house, OL_EnergyAssetType.PHOTOVOLTAIC, "Residential Solar", installedRooftopSolar_kW);
 }
 /*ALCODEEND*/}
 
-double f_addPVProductionAsset(GridConnection parentGC,String asset_name,double installedPower_kW,OL_Orientation orientation,double roofPitch_deg)
+double f_addPVProductionAsset(GridConnection parentGC,String asset_name,double installedPower_kW,OL_PVOrientation pvOrientation)
 {/*ALCODESTART::1773414911038*/
 J_TimeParameters timeParameters = energyModel.p_timeParameters;
 OL_EnergyCarriers energyCarrier = OL_EnergyCarriers.ELECTRICITY;
-J_ProfilePointer profilePointer = f_determinePVTProfilePointer(orientation, roofPitch_deg);
+J_ProfilePointer profilePointer = f_getPVTProfilePointer(pvOrientation);
 
 J_EAProduction production_asset = new J_EAProduction(parentGC, OL_EnergyAssetType.PHOTOVOLTAIC, asset_name, energyCarrier, installedPower_kW, timeParameters, profilePointer);
 /*ALCODEEND*/}
 
-J_ProfilePointer f_determinePVTProfilePointer(OL_Orientation orientation,double roofPitch_deg)
+J_ProfilePointer f_getPVTProfilePointer(OL_PVOrientation pvtOrientation)
 {/*ALCODESTART::1773414911040*/
 J_ProfilePointer profilePointer = null;
 
-switch (orientation){
+switch (pvtOrientation){
 	case EASTWEST:
-		if (roofPitch_deg <= 15 && roofPitch_deg >= 0){
-			profilePointer = energyModel.pp_PVProduction15DegEastWest_fr;
-		}
-		else {
-			throw new RuntimeException("ProfilePointer for a combination of " + orientation + " and " + roofPitch_deg + " is not supported (yet)!");
-		}
+		profilePointer = energyModel.pp_PVProduction15DegEastWest_fr;
 	case SOUTH:
-		if (roofPitch_deg <= 35 && roofPitch_deg >= 0){
-			profilePointer = energyModel.pp_PVProduction35DegSouth_fr;
-		}
-		else {
-			throw new RuntimeException("ProfilePointer for a combination of " + orientation + " and " + roofPitch_deg + " is not supported (yet)!");
-		}
+		profilePointer = energyModel.pp_PVProduction35DegSouth_fr;
 }
 
 return profilePointer;
@@ -5279,12 +5270,12 @@ J_ProfilePointer profilePointer = energyModel.pp_windProduction_fr;
 J_EAProduction production_asset = new J_EAProduction(parentGC, OL_EnergyAssetType.WINDMILL, asset_name, energyCarrier, installedPower_kW, timeParameters, profilePointer);
 /*ALCODEEND*/}
 
-double f_addPTProductionAsset(GridConnection parentGC,String asset_name,double installedPower_kW,OL_Orientation orientation,int roofPitch_deg)
+double f_addPTProductionAsset(GridConnection parentGC,String asset_name,double installedPower_kW,OL_PVOrientation ptOrientation)
 {/*ALCODESTART::1773414911044*/
 //CONCEPT VERSION
 J_TimeParameters timeParameters = energyModel.p_timeParameters;
 OL_EnergyCarriers energyCarrier = OL_EnergyCarriers.HEAT;
-J_ProfilePointer profilePointer = f_determinePVTProfilePointer(orientation, roofPitch_deg);
+J_ProfilePointer profilePointer = f_getPVTProfilePointer(ptOrientation);
 
 J_EAProduction production_asset = new J_EAProduction(parentGC, OL_EnergyAssetType.PHOTOVOLTAIC, asset_name, energyCarrier, installedPower_kW, timeParameters, profilePointer);
 /*ALCODEEND*/}

--- a/_alp/Agents/Zero_Loader/Code/Functions.java
+++ b/_alp/Agents/Zero_Loader/Code/Functions.java
@@ -303,8 +303,8 @@ for (Solarfarm_data dataSolarfarm : f_getSolarfarmsInSubScope(c_solarfarm_data))
 			} 
 		}
 		if(gridNodeProfileLoaderType != OL_GridNodeProfileLoaderType.INCLUDE_PV || gridNodeProfileLoaderType != OL_GridNodeProfileLoaderType.NET_LOAD){
-			f_addPVProductionAsset(solarpark, "Solar farm" , dataSolarfarm.capacity_electric_kw(), dataSolarfarm.orientation());
-			//f_addEnergyProduction(solarpark, OL_EnergyAssetType.PHOTOVOLTAIC, "Solar farm" , dataSolarfarm.capacity_electric_kw());
+			OL_PVOrientation pvOrientation = dataSolarfarm.orientation() != null ? dataSolarfarm.orientation() : avgc_data.p_defaultPVOrientation;
+			f_addPVProductionAsset(solarpark, "Solar farm" , dataSolarfarm.capacity_electric_kw(), pvOrientation);
 		}
 		
 		//Set owner
@@ -846,7 +846,8 @@ for (Building_data genericCompany : buildingDataGenericCompanies) {
 	 	
 	 	//Set PV information
 		companyGC.v_liveAssetsMetaData.initialPV_kW = genericCompany.pv_installed_kwp() != null ? genericCompany.pv_installed_kwp() : 0;
-		//companyGC.v_liveAssetsMetaData.PVPotential_kW = ; // Still needs to be calculated
+		companyGC.v_liveAssetsMetaData.PVPotential_kW = genericCompany.pv_potential_kwp(); // if null: pv potential will be determined by sliders!
+	 	companyGC.v_liveAssetsMetaData.PVOrientation = genericCompany.pv_orientation() != null ? genericCompany.pv_orientation() : avgc_data.p_defaultPVOrientation;
 	 	
 	 	//Update remaining totals (AFTER Lat/Lon has been defined!)
 		p_remainingTotals.adjustTotalNumberOfAnonymousCompanies(companyGC, 1);
@@ -892,7 +893,7 @@ p_remainingTotals.finalizeRemainingTotalsDistributionCompanies();
 
 //Add EA to all generic companies (Has to be after the remaining totals finalization, so cant happen at the same time as the creation of the GC and their buildings)
 for (GridConnection GCcompany : generic_company_GCs ) {
-	f_iEAGenericCompanies(GCcompany, GCcompany.v_liveAssetsMetaData.initialPV_kW);
+	f_iEAGenericCompanies(GCcompany);
 }
 /*ALCODEEND*/}
 
@@ -1434,7 +1435,7 @@ switch (storageType){
 
 /*ALCODEEND*/}
 
-double f_iEAGenericCompanies(GridConnection companyGC,Double pv_installed_kwp)
+double f_iEAGenericCompanies(GridConnection companyGC)
 {/*ALCODESTART::1726584205833*/
 //Get GridNode to know if it has a GridNode profile
 OL_GridNodeProfileLoaderType gridNodeProfileLoaderType = OL_GridNodeProfileLoaderType.NO_PROFILE;
@@ -1493,16 +1494,18 @@ if (companyGC.p_floorSurfaceArea_m2 > 0){
 }
 
 
-//Production asset (PV) ??????????????????????????????????????????? willen we die toevoegen aan generieke bedrijven?
+//Production asset (PV)
+Double pv_installed_kwp = companyGC.v_liveAssetsMetaData.initialPV_kW;
 if (gridNodeProfileLoaderType == OL_GridNodeProfileLoaderType.INCLUDE_PV || gridNodeProfileLoaderType == OL_GridNodeProfileLoaderType.NET_LOAD){ //dont count production if there is measured data on Node
 	pv_installed_kwp = 0.0;
 }
 if(pv_installed_kwp != null && pv_installed_kwp > 0){
-	f_addPVProductionAsset(companyGC, "Rooftop Solar", pv_installed_kwp, OL_PVOrientation.SOUTH);
-	//f_addEnergyProduction(companyGC, OL_EnergyAssetType.PHOTOVOLTAIC, "Rooftop Solar", pv_installed_kwp);
+	f_addPVProductionAsset(companyGC, "Rooftop Solar", pv_installed_kwp, companyGC.v_liveAssetsMetaData.PVOrientation);
 	
 	current_scenario_list.setCurrentPV_kW(roundToInt(pv_installed_kwp));
+	current_scenario_list.setCurrentPV_orientation(companyGC.v_liveAssetsMetaData.PVOrientation);
 	future_scenario_list.setPlannedPV_kW(roundToInt(pv_installed_kwp));
+	future_scenario_list.setPlannedPV_orientation(companyGC.v_liveAssetsMetaData.PVOrientation);
 }
 
 
@@ -2334,31 +2337,48 @@ if (gridConnection.getSupply().getHasSupply() != null && gridConnection.getSuppl
 	}
 	if (yearlyElectricityProduction_kWh_array != null && gridConnection.getSupply().getPvInstalledKwp() != null && gridConnection.getSupply().getPvInstalledKwp() > 0 && !gridConnection.getHeat().getHeatingTypes().contains(com.zenmo.zummon.companysurvey.HeatingType.COMBINED_HEAT_AND_POWER)){
 		f_createCustomPVAsset(companyGC, yearlyElectricityProduction_kWh_array, (double)gridConnection.getSupply().getPvInstalledKwp()); // Create custom PV asset when production data is available!
+		
+		companyGC.v_liveAssetsMetaData.PVOrientation = OL_PVOrientation.CUSTOM;
+		companyGC.v_liveAssetsMetaData.initialPV_kW = (double)gridConnection.getSupply().getPvInstalledKwp();
 		current_scenario_list.setCurrentPV_kW(gridConnection.getSupply().getPvInstalledKwp());
-	} else if (gridConnection.getSupply().getPvInstalledKwp() != null && gridConnection.getSupply().getPvInstalledKwp() > 0){			
-		//gridConnection.getSupply().getPvOrientation(); // Wat doen we hier mee????? Nog niets!
-		f_addPVProductionAsset(companyGC, "Rooftop Solar", (double) gridConnection.getSupply().getPvInstalledKwp(), OL_PVOrientation.SOUTH); //NEEDS FIXING
-		//f_addEnergyProduction(companyGC, OL_EnergyAssetType.PHOTOVOLTAIC, "Rooftop Solar", gridConnection.getSupply().getPvInstalledKwp());
+		current_scenario_list.setCurrentPV_orientation(OL_PVOrientation.CUSTOM);
+	} 
+	else if (gridConnection.getSupply().getPvInstalledKwp() != null && gridConnection.getSupply().getPvInstalledKwp() > 0){			
+		OL_PVOrientation installedPVOrientation = f_getPVOrientationFromZorm(gridConnection.getSupply().getPvOrientation());
+		f_addPVProductionAsset(companyGC, "Rooftop Solar", (double) gridConnection.getSupply().getPvInstalledKwp(), installedPVOrientation);
 		
 		//add to scenario: current
+		companyGC.v_liveAssetsMetaData.initialPV_kW = (double)gridConnection.getSupply().getPvInstalledKwp();
+		companyGC.v_liveAssetsMetaData.PVOrientation = installedPVOrientation;
 		current_scenario_list.setCurrentPV_kW(gridConnection.getSupply().getPvInstalledKwp());
-		//current_scenario_list.currentPV_orient = gridConnection.getSupply().getPvOrientation();
+		current_scenario_list.setCurrentPV_orientation(installedPVOrientation);
+	}
+	else{
+		companyGC.v_liveAssetsMetaData.initialPV_kW = 0.0;
+		companyGC.v_liveAssetsMetaData.PVOrientation = avgc_data.p_defaultPVOrientation;
+		current_scenario_list.setCurrentPV_kW(0);
+		current_scenario_list.setCurrentPV_orientation(avgc_data.p_defaultPVOrientation);
 	} 	
 	//Wind
 	if (gridConnection.getSupply().getWindInstalledKw() != null && gridConnection.getSupply().getWindInstalledKw() > 0){
 		f_addWindProductionAsset(companyGC, "Wind mill", gridConnection.getSupply().getWindInstalledKw());
-		//f_addEnergyProduction(companyGC, OL_EnergyAssetType.WINDMILL, "Wind mill", gridConnection.getSupply().getWindInstalledKw());
 
 		//add to scenario: current
 		current_scenario_list.setCurrentWind_kW(gridConnection.getSupply().getWindInstalledKw());
 	}
+}
+else{
+	companyGC.v_liveAssetsMetaData.initialPV_kW = 0.0;
+	companyGC.v_liveAssetsMetaData.PVOrientation = avgc_data.p_defaultPVOrientation;
+	current_scenario_list.setCurrentPV_kW(0);
+	current_scenario_list.setCurrentPV_orientation(avgc_data.p_defaultPVOrientation);
 }
 
 //Planned supply (PV)
 if (gridConnection.getSupply().getPvPlanned() != null && gridConnection.getSupply().getPvPlanned()){
 	future_scenario_list.setPlannedPV_kW(current_scenario_list.getCurrentPV_kW() + (gridConnection.getSupply().getPvPlannedKwp() != null ? gridConnection.getSupply().getPvPlannedKwp() : 0)); 
 	future_scenario_list.setPlannedPV_year(gridConnection.getSupply().getPvPlannedYear());
-	//gridConnection.getSupply().getPvPlannedOrientation();
+	future_scenario_list.setPlannedPV_orientation(f_getPVOrientationFromZorm(gridConnection.getSupply().getPvPlannedOrientation()));
 }
 else{
 	future_scenario_list.setPlannedPV_kW(current_scenario_list.getCurrentPV_kW());
@@ -5219,6 +5239,9 @@ J_ProfilePointer f_getPVTProfilePointer(OL_PVOrientation pvtOrientation)
 {/*ALCODESTART::1773414911040*/
 J_ProfilePointer profilePointer = null;
 
+if(pvtOrientation == null){
+	throw new RuntimeException("Trying to get a pvt profile pointer whithout specifying the orientation. Not allowed!");
+}
 switch (pvtOrientation){
 	case EASTWEST:
 		profilePointer = energyModel.pp_PVProduction15DegEastWest_fr;
@@ -5246,5 +5269,23 @@ OL_EnergyCarriers energyCarrier = OL_EnergyCarriers.HEAT;
 J_ProfilePointer profilePointer = f_getPVTProfilePointer(ptOrientation);
 
 J_EAProduction production_asset = new J_EAProduction(parentGC, OL_EnergyAssetType.PHOTOVOLTAIC, asset_name, energyCarrier, installedPower_kW, timeParameters, profilePointer);
+/*ALCODEEND*/}
+
+OL_PVOrientation f_getPVOrientationFromZorm(com.zenmo.zummon.companysurvey.PVOrientation PVOrientationZorm)
+{/*ALCODESTART::1775121934632*/
+OL_PVOrientation pvOrientation = avgc_data.p_defaultPVOrientation;
+
+if(PVOrientationZorm != null){
+	switch(PVOrientationZorm){
+		case SOUTH:
+			pvOrientation = OL_PVOrientation.EASTWEST;
+			break;
+		case EAST_WEST:
+			pvOrientation = OL_PVOrientation.EASTWEST;
+			break;
+	}
+}
+
+return pvOrientation;
 /*ALCODEEND*/}
 

--- a/_alp/Agents/Zero_Loader/Code/Functions.xml
+++ b/_alp/Agents/Zero_Loader/Code/Functions.xml
@@ -320,6 +320,7 @@
 		<ReturnType>double</ReturnType>
 		<Id>1726584205809</Id>
 		<Name><![CDATA[f_addEnergyProduction]]></Name>
+		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>1320</X>
 		<Y>190</Y>
 		<Label>
@@ -1501,6 +1502,14 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Parameter>
 			<Name><![CDATA[cookingType]]></Name>
 			<Type><![CDATA[OL_HouseholdCookingMethod]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[orientation]]></Name>
+			<Type><![CDATA[OL_Orientation]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[roofPitch_deg]]></Name>
+			<Type><![CDATA[double]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
@@ -2744,7 +2753,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="default" StaticFunction="false">
+	<Function AccessType="protected" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1768486498278</Id>
@@ -2854,6 +2863,138 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Parameter>
 			<Name><![CDATA[gn]]></Name>
 			<Type><![CDATA[GridNode]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[orientation]]></Name>
+			<Type><![CDATA[OL_Orientation]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[roofPitch_deg]]></Name>
+			<Type><![CDATA[double]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="public" StaticFunction="false">
+		<ReturnModificator>VOID</ReturnModificator>
+		<ReturnType>double</ReturnType>
+		<Id>1773414911038</Id>
+		<Name><![CDATA[f_addPVProductionAsset]]></Name>
+		<X>1510</X>
+		<Y>180</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[parentGC]]></Name>
+			<Type><![CDATA[GridConnection]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[asset_name]]></Name>
+			<Type><![CDATA[String]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[installedPower_kW]]></Name>
+			<Type><![CDATA[double]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[orientation]]></Name>
+			<Type><![CDATA[OL_Orientation]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[roofPitch_deg]]></Name>
+			<Type><![CDATA[double]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="public" StaticFunction="false">
+		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+		<ReturnType>J_ProfilePointer</ReturnType>
+		<Id>1773414911040</Id>
+		<Name><![CDATA[f_determinePVTProfilePointer]]></Name>
+		<X>1530</X>
+		<Y>220</Y>
+		<Label>
+			<X>12</X>
+			<Y>1</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[orientation]]></Name>
+			<Type><![CDATA[OL_Orientation]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[roofPitch_deg]]></Name>
+			<Type><![CDATA[double]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="public" StaticFunction="false">
+		<ReturnModificator>VOID</ReturnModificator>
+		<ReturnType>double</ReturnType>
+		<Id>1773414911042</Id>
+		<Name><![CDATA[f_addWindProductionAsset]]></Name>
+		<X>1510</X>
+		<Y>160</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[parentGC]]></Name>
+			<Type><![CDATA[GridConnection]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[asset_name]]></Name>
+			<Type><![CDATA[String]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[installedPower_kW]]></Name>
+			<Type><![CDATA[double]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="public" StaticFunction="false">
+		<ReturnModificator>VOID</ReturnModificator>
+		<ReturnType>double</ReturnType>
+		<Id>1773414911044</Id>
+		<Name><![CDATA[f_addPTProductionAsset]]></Name>
+		<X>1510</X>
+		<Y>200</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[parentGC]]></Name>
+			<Type><![CDATA[GridConnection]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[asset_name]]></Name>
+			<Type><![CDATA[String]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[installedPower_kW]]></Name>
+			<Type><![CDATA[double]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[orientation]]></Name>
+			<Type><![CDATA[OL_Orientation]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[roofPitch_deg]]></Name>
+			<Type><![CDATA[int]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>

--- a/_alp/Agents/Zero_Loader/Code/Functions.xml
+++ b/_alp/Agents/Zero_Loader/Code/Functions.xml
@@ -544,10 +544,6 @@
 			<Name><![CDATA[companyGC]]></Name>
 			<Type><![CDATA[GridConnection]]></Type>
 		</Parameter>
-		<Parameter>
-			<Name><![CDATA[pv_installed_kwp]]></Name>
-			<Type><![CDATA[Double]]></Type>
-		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
 	<Function AccessType="protected" StaticFunction="false">
@@ -2942,6 +2938,26 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Parameter>
 			<Name><![CDATA[ptOrientation]]></Name>
 			<Type><![CDATA[OL_PVOrientation]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="default" StaticFunction="false">
+		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+		<ReturnType>OL_PVOrientation</ReturnType>
+		<Id>1775121934632</Id>
+		<Name><![CDATA[f_getPVOrientationFromZorm]]></Name>
+		<X>490</X>
+		<Y>500</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[PVOrientationZorm]]></Name>
+			<Type><![CDATA[com.zenmo.zummon.companysurvey.PVOrientation]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>

--- a/_alp/Agents/Zero_Loader/Code/Functions.xml
+++ b/_alp/Agents/Zero_Loader/Code/Functions.xml
@@ -1466,10 +1466,6 @@ verbruik = levering + productie - teruglevering]]></Description>
 			<Name><![CDATA[cookingType]]></Name>
 			<Type><![CDATA[OL_HouseholdCookingMethod]]></Type>
 		</Parameter>
-		<Parameter>
-			<Name><![CDATA[pvOrientation]]></Name>
-			<Type><![CDATA[OL_PVOrientation]]></Type>
-		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
 	<Function AccessType="protected" StaticFunction="false">
@@ -2822,10 +2818,6 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Parameter>
 			<Name><![CDATA[gn]]></Name>
 			<Type><![CDATA[GridNode]]></Type>
-		</Parameter>
-		<Parameter>
-			<Name><![CDATA[pvOrientation]]></Name>
-			<Type><![CDATA[OL_PVOrientation]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>

--- a/_alp/Agents/Zero_Loader/Code/Functions.xml
+++ b/_alp/Agents/Zero_Loader/Code/Functions.xml
@@ -1504,12 +1504,8 @@ verbruik = levering + productie - teruglevering]]></Description>
 			<Type><![CDATA[OL_HouseholdCookingMethod]]></Type>
 		</Parameter>
 		<Parameter>
-			<Name><![CDATA[orientation]]></Name>
-			<Type><![CDATA[OL_Orientation]]></Type>
-		</Parameter>
-		<Parameter>
-			<Name><![CDATA[roofPitch_deg]]></Name>
-			<Type><![CDATA[double]]></Type>
+			<Name><![CDATA[pvOrientation]]></Name>
+			<Type><![CDATA[OL_PVOrientation]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
@@ -2865,12 +2861,8 @@ verbruik = levering + productie - teruglevering]]></Description>
 			<Type><![CDATA[GridNode]]></Type>
 		</Parameter>
 		<Parameter>
-			<Name><![CDATA[orientation]]></Name>
-			<Type><![CDATA[OL_Orientation]]></Type>
-		</Parameter>
-		<Parameter>
-			<Name><![CDATA[roofPitch_deg]]></Name>
-			<Type><![CDATA[double]]></Type>
+			<Name><![CDATA[pvOrientation]]></Name>
+			<Type><![CDATA[OL_PVOrientation]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
@@ -2901,12 +2893,8 @@ verbruik = levering + productie - teruglevering]]></Description>
 			<Type><![CDATA[double]]></Type>
 		</Parameter>
 		<Parameter>
-			<Name><![CDATA[orientation]]></Name>
-			<Type><![CDATA[OL_Orientation]]></Type>
-		</Parameter>
-		<Parameter>
-			<Name><![CDATA[roofPitch_deg]]></Name>
-			<Type><![CDATA[double]]></Type>
+			<Name><![CDATA[pvOrientation]]></Name>
+			<Type><![CDATA[OL_PVOrientation]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
@@ -2914,7 +2902,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
 		<ReturnType>J_ProfilePointer</ReturnType>
 		<Id>1773414911040</Id>
-		<Name><![CDATA[f_determinePVTProfilePointer]]></Name>
+		<Name><![CDATA[f_getPVTProfilePointer]]></Name>
 		<X>1530</X>
 		<Y>220</Y>
 		<Label>
@@ -2925,12 +2913,8 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<PresentationFlag>true</PresentationFlag>
 		<ShowLabel>true</ShowLabel>
 		<Parameter>
-			<Name><![CDATA[orientation]]></Name>
-			<Type><![CDATA[OL_Orientation]]></Type>
-		</Parameter>
-		<Parameter>
-			<Name><![CDATA[roofPitch_deg]]></Name>
-			<Type><![CDATA[double]]></Type>
+			<Name><![CDATA[pvtOrientation]]></Name>
+			<Type><![CDATA[OL_PVOrientation]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
@@ -2989,12 +2973,8 @@ verbruik = levering + productie - teruglevering]]></Description>
 			<Type><![CDATA[double]]></Type>
 		</Parameter>
 		<Parameter>
-			<Name><![CDATA[orientation]]></Name>
-			<Type><![CDATA[OL_Orientation]]></Type>
-		</Parameter>
-		<Parameter>
-			<Name><![CDATA[roofPitch_deg]]></Name>
-			<Type><![CDATA[int]]></Type>
+			<Name><![CDATA[ptOrientation]]></Name>
+			<Type><![CDATA[OL_PVOrientation]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>

--- a/_alp/Agents/Zero_Loader/Code/Functions.xml
+++ b/_alp/Agents/Zero_Loader/Code/Functions.xml
@@ -315,39 +315,6 @@
 		<ShowLabel>true</ShowLabel>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="public" StaticFunction="false">
-		<ReturnModificator>VOID</ReturnModificator>
-		<ReturnType>double</ReturnType>
-		<Id>1726584205809</Id>
-		<Name><![CDATA[f_addEnergyProduction]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1320</X>
-		<Y>190</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Parameter>
-			<Name><![CDATA[parentGC]]></Name>
-			<Type><![CDATA[GridConnection]]></Type>
-		</Parameter>
-		<Parameter>
-			<Name><![CDATA[asset_type]]></Name>
-			<Type><![CDATA[OL_EnergyAssetType]]></Type>
-		</Parameter>
-		<Parameter>
-			<Name><![CDATA[asset_name]]></Name>
-			<Type><![CDATA[String]]></Type>
-		</Parameter>
-		<Parameter>
-			<Name><![CDATA[installedPower_kW]]></Name>
-			<Type><![CDATA[double]]></Type>
-		</Parameter>
-		<Body xmlns:al="http://anylogic.com"/>
-	</Function>
 	<Function AccessType="protected" StaticFunction="false">
 		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
 		<ReturnType>GIS_Object</ReturnType>
@@ -464,7 +431,7 @@
 		<Id>1726584205827</Id>
 		<Name><![CDATA[f_addElectricVehicle]]></Name>
 		<X>1320</X>
-		<Y>620</Y>
+		<Y>590</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -500,7 +467,7 @@
 		<Id>1726584205829</Id>
 		<Name><![CDATA[f_addPetroleumFuelVehicle]]></Name>
 		<X>1320</X>
-		<Y>640</Y>
+		<Y>610</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -605,7 +572,7 @@
 		<Id>1726584205837</Id>
 		<Name><![CDATA[f_addTransportHydrogen]]></Name>
 		<X>1320</X>
-		<Y>660</Y>
+		<Y>630</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -918,11 +885,11 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<ReturnType>double</ReturnType>
 		<Id>1732112209863</Id>
 		<Name><![CDATA[f_createCustomPVAsset]]></Name>
-		<X>1320</X>
-		<Y>210</Y>
+		<X>1340</X>
+		<Y>250</Y>
 		<Label>
-			<X>9</X>
-			<Y>-1</Y>
+			<X>12</X>
+			<Y>0</Y>
 		</Label>
 		<PublicFlag>false</PublicFlag>
 		<PresentationFlag>true</PresentationFlag>
@@ -995,7 +962,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1737712184349</Id>
 		<Name><![CDATA[f_createPetroleumFuelTractors]]></Name>
 		<X>1320</X>
-		<Y>680</Y>
+		<Y>650</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1091,7 +1058,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1745336570663</Id>
 		<Name><![CDATA[f_addHeatAsset]]></Name>
 		<X>1320</X>
-		<Y>430</Y>
+		<Y>460</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1353,7 +1320,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1749726189312</Id>
 		<Name><![CDATA[f_addCookingAsset]]></Name>
 		<X>1320</X>
-		<Y>500</Y>
+		<Y>510</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1381,7 +1348,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1749726279652</Id>
 		<Name><![CDATA[f_addHotWaterDemand]]></Name>
 		<X>1320</X>
-		<Y>520</Y>
+		<Y>530</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1405,7 +1372,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1749727623536</Id>
 		<Name><![CDATA[f_addBuildingHeatModel]]></Name>
 		<X>1320</X>
-		<Y>400</Y>
+		<Y>430</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1864,7 +1831,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1753883660006</Id>
 		<Name><![CDATA[f_createHeatProfileFromAnnualGasTotal]]></Name>
 		<X>1320</X>
-		<Y>295</Y>
+		<Y>325</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1896,7 +1863,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1753883738731</Id>
 		<Name><![CDATA[f_createGasProfileFromAnnualGasTotal]]></Name>
 		<X>1320</X>
-		<Y>250</Y>
+		<Y>280</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2050,7 +2017,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1753951013582</Id>
 		<Name><![CDATA[f_getGasToHeatEfficiency]]></Name>
 		<X>1340</X>
-		<Y>315</Y>
+		<Y>345</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2090,7 +2057,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1753955686832</Id>
 		<Name><![CDATA[f_createGasProfileFromEstimates]]></Name>
 		<X>1320</X>
-		<Y>270</Y>
+		<Y>300</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2110,7 +2077,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1753961830063</Id>
 		<Name><![CDATA[f_createHeatProfileFromEstimates]]></Name>
 		<X>1320</X>
-		<Y>360</Y>
+		<Y>390</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2192,7 +2159,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1753964605708</Id>
 		<Name><![CDATA[f_createHeatProfileFromAnnualHeatTotal]]></Name>
 		<X>1320</X>
-		<Y>340</Y>
+		<Y>370</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2301,7 +2268,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<Id>1754050106254</Id>
 		<Name><![CDATA[f_addCustomHeatAsset]]></Name>
 		<X>1340</X>
-		<Y>450</Y>
+		<Y>480</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2871,8 +2838,8 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<ReturnType>double</ReturnType>
 		<Id>1773414911038</Id>
 		<Name><![CDATA[f_addPVProductionAsset]]></Name>
-		<X>1510</X>
-		<Y>180</Y>
+		<X>1320</X>
+		<Y>210</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2903,8 +2870,8 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<ReturnType>J_ProfilePointer</ReturnType>
 		<Id>1773414911040</Id>
 		<Name><![CDATA[f_getPVTProfilePointer]]></Name>
-		<X>1530</X>
-		<Y>220</Y>
+		<X>1340</X>
+		<Y>230</Y>
 		<Label>
 			<X>12</X>
 			<Y>1</Y>
@@ -2923,8 +2890,8 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<ReturnType>double</ReturnType>
 		<Id>1773414911042</Id>
 		<Name><![CDATA[f_addWindProductionAsset]]></Name>
-		<X>1510</X>
-		<Y>160</Y>
+		<X>1320</X>
+		<Y>170</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2951,8 +2918,8 @@ verbruik = levering + productie - teruglevering]]></Description>
 		<ReturnType>double</ReturnType>
 		<Id>1773414911044</Id>
 		<Name><![CDATA[f_addPTProductionAsset]]></Name>
-		<X>1510</X>
-		<Y>200</Y>
+		<X>1320</X>
+		<Y>190</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>

--- a/_alp/Agents/Zero_Loader/EmbeddedObjects.xml
+++ b/_alp/Agents/Zero_Loader/EmbeddedObjects.xml
@@ -433,6 +433,9 @@
 			<Parameter>
 				<Name><![CDATA[p_defaultNrOfSocketsPerCharger]]></Name>
 			</Parameter>
+			<Parameter>
+				<Name><![CDATA[p_defaultPVOrientation]]></Name>
+			</Parameter>
 		</Parameters>
 		<ReplicationFlag>false</ReplicationFlag>
 		<Replication Class="CodeValue">

--- a/_alp/Agents/tabElectricity/Code/Functions.java
+++ b/_alp/Agents/tabElectricity/Code/Functions.java
@@ -66,16 +66,13 @@ while ( nbHousesWithPVGoal > nbHousesWithPV ) {
 	}
 	else {
 		String assetName = "Rooftop PV";
-		double capacityHeat_kW = 0.0;
-		double yearlyProductionHydrogen_kWh = 0.0;
-		double yearlyProductionMethane_kWh = 0.0;
-		double installedPVCapacity_kW = house.v_liveAssetsMetaData.PVPotential_kW;//roundToDecimal(uniform(3,6),2);
+		double installedPVCapacity_kW = house.v_liveAssetsMetaData.PVPotential_kW;
 		
 		//Compensate for pt if it is present
 		if(house.v_liveAssetsMetaData.activeAssetFlows.contains(OL_AssetFlowCategories.ptProductionHeat_kW)){
 			installedPVCapacity_kW = max(0, installedPVCapacity_kW-zero_Interface.energyModel.avgc_data.p_avgPTPanelSize_m2*zero_Interface.energyModel.avgc_data.p_avgPVPower_kWpm2); //For now just 1 panel
 		}
-		J_ProfilePointer profilePointer = f_getPVTProfilePointer(house.v_liveAssetsMetaData.PVOrientation);
+		J_ProfilePointer profilePointer = f_getPVTProfilePointer(house.v_liveAssetsMetaData.PVOrientation, house.p_gridConnectionID);
 		J_EAProduction productionAsset = new J_EAProduction ( house, OL_EnergyAssetType.PHOTOVOLTAIC, assetName, OL_EnergyCarriers.ELECTRICITY, installedPVCapacity_kW, zero_Interface.energyModel.p_timeParameters, profilePointer );
 		houses.remove(house);
 		zero_Interface.c_orderedPVSystemsHouses.remove(house);
@@ -261,12 +258,7 @@ else {
 	// Create a new asset
 	OL_EnergyAssetType assetType = OL_EnergyAssetType.PHOTOVOLTAIC;
 	String assetName = "Rooftop PV";
-	double capacityHeat_kW = 0.0;
-	double yearlyProductionMethane_kWh = 0.0;
-	double yearlyProductionHydrogen_kWh = 0.0;
-	double outputTemperature_degC = 0.0;
-	
-	J_ProfilePointer profilePointer = f_getPVTProfilePointer(gc.v_liveAssetsMetaData.PVOrientation);
+	J_ProfilePointer profilePointer = f_getPVTProfilePointer(gc.v_liveAssetsMetaData.PVOrientation, gc.p_gridConnectionID);
 	J_EAProduction productionAsset = new J_EAProduction ( gc, assetType, assetName, OL_EnergyCarriers.ELECTRICITY, capacity_kWp, zero_Interface.energyModel.p_timeParameters, profilePointer );
 }
 
@@ -740,15 +732,23 @@ for(GCGridBattery GCBat : uI_Tabs.f_getAllSliderGridConnections_gridBatteries())
 }
 /*ALCODEEND*/}
 
-J_ProfilePointer f_getPVTProfilePointer(OL_PVOrientation pvtOrientation)
+J_ProfilePointer f_getPVTProfilePointer(OL_PVOrientation pvtOrientation,String gridConnectionID)
 {/*ALCODESTART::1773764103422*/
 J_ProfilePointer profilePointer = null;
 
 switch (pvtOrientation){
 	case EASTWEST:
 		profilePointer = zero_Interface.energyModel.pp_PVProduction15DegEastWest_fr;
+		break;
 	case SOUTH:
 		profilePointer = zero_Interface.energyModel.pp_PVProduction35DegSouth_fr;
+		break;
+	case CUSTOM:
+		profilePointer = zero_Interface.energyModel.f_findProfile("GC: " + gridConnectionID + " custom pv profile");
+		if(profilePointer == null){
+			throw new RuntimeException("Can't find custom profile pointer for GC with custom orientation.");
+		}
+		break;
 }
 
 return profilePointer;

--- a/_alp/Agents/tabElectricity/Code/Functions.java
+++ b/_alp/Agents/tabElectricity/Code/Functions.java
@@ -75,7 +75,8 @@ while ( nbHousesWithPVGoal > nbHousesWithPV ) {
 		if(house.v_liveAssetsMetaData.activeAssetFlows.contains(OL_AssetFlowCategories.ptProductionHeat_kW)){
 			installedPVCapacity_kW = max(0, installedPVCapacity_kW-zero_Interface.energyModel.avgc_data.p_avgPTPanelSize_m2*zero_Interface.energyModel.avgc_data.p_avgPVPower_kWpm2); //For now just 1 panel
 		}
-		J_EAProduction productionAsset = new J_EAProduction ( house, OL_EnergyAssetType.PHOTOVOLTAIC, assetName, OL_EnergyCarriers.ELECTRICITY, installedPVCapacity_kW, zero_Interface.energyModel.p_timeParameters, zero_Interface.energyModel.pp_PVProduction35DegSouth_fr );
+		J_ProfilePointer profilePointer = f_getPVTProfilePointer(house.v_liveAssetsMetaData.PVOrientation);
+		J_EAProduction productionAsset = new J_EAProduction ( house, OL_EnergyAssetType.PHOTOVOLTAIC, assetName, OL_EnergyCarriers.ELECTRICITY, installedPVCapacity_kW, zero_Interface.energyModel.p_timeParameters, profilePointer );
 		houses.remove(house);
 		zero_Interface.c_orderedPVSystemsHouses.remove(house);
 		zero_Interface.c_orderedPVSystemsHouses.add(0, house);
@@ -271,7 +272,8 @@ else {
 	double yearlyProductionHydrogen_kWh = 0.0;
 	double outputTemperature_degC = 0.0;
 	
-	J_EAProduction productionAsset = new J_EAProduction ( gc, assetType, assetName, OL_EnergyCarriers.ELECTRICITY, capacity_kWp, zero_Interface.energyModel.p_timeParameters, zero_Interface.energyModel.pp_PVProduction35DegSouth_fr );
+	J_ProfilePointer profilePointer = f_getPVTProfilePointer(gc.v_liveAssetsMetaData.PVOrientation);
+	J_EAProduction productionAsset = new J_EAProduction ( gc, assetType, assetName, OL_EnergyCarriers.ELECTRICITY, capacity_kWp, zero_Interface.energyModel.p_timeParameters, profilePointer );
 }
 
 // Update the ordered collection
@@ -751,5 +753,19 @@ for(GCGridBattery GCBat : uI_Tabs.f_getAllSliderGridConnections_gridBatteries())
 		p_currentTotalGridBatteryCapacity_MWh += (GCBat.p_batteryAsset.getStorageCapacity_kWh()/1000.0);
 	}
 }
+/*ALCODEEND*/}
+
+J_ProfilePointer f_getPVTProfilePointer(OL_PVOrientation pvtOrientation)
+{/*ALCODESTART::1773764103422*/
+J_ProfilePointer profilePointer = null;
+
+switch (pvtOrientation){
+	case EASTWEST:
+		profilePointer = zero_Interface.energyModel.pp_PVProduction15DegEastWest_fr;
+	case SOUTH:
+		profilePointer = zero_Interface.energyModel.pp_PVProduction35DegSouth_fr;
+}
+
+return profilePointer;
 /*ALCODEEND*/}
 

--- a/_alp/Agents/tabElectricity/Code/Functions.xml
+++ b/_alp/Agents/tabElectricity/Code/Functions.xml
@@ -7,7 +7,7 @@
 		<Name><![CDATA[f_setPVOnLand]]></Name>
 		<Description><![CDATA[Function that changes the electric capacity of the energy asset of the "Solar field". Takes an area size in hectares as a parameter and assumes that 1 MWp of solarpannels fits on 1 ha. The variables for amount of installed PV are updated automatically in the zero_engine. The function also modifies the connection capacity of the energy production site to match the new installed PV Power. Passing a list of gcs sets all gcs to the same input value.]]></Description>
 		<X>70</X>
-		<Y>840</Y>
+		<Y>860</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -33,7 +33,7 @@
 		<Description><![CDATA[Function that adds or removes photovoltaic production assets to houses. Takes a percentage as a parameter and runs untill that percentage of all the houses has a PV asset. If a new asset is created it takes as its electric capacity a random value between 3 and 6 kW. The variables for amount of installed PV are updated automatically in the zero_engine.
 ]]></Description>
 		<X>70</X>
-		<Y>810</Y>
+		<Y>830</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -58,7 +58,7 @@
 		<Name><![CDATA[f_setWindTurbines]]></Name>
 		<Description><![CDATA[Function that changes the electric capacity of the energy asset of the "Wind Farm". Takes an amount of MW as a parameter. The variables for amount of installed Wind are updated automatically in the zero_engine. The function also modifies the connection capacity of the energy production site to match the new installed Wind Power. Passing a list of gcs sets all gcs to the same input value.]]></Description>
 		<X>70</X>
-		<Y>870</Y>
+		<Y>890</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -218,7 +218,7 @@
 		<Id>1750063382310</Id>
 		<Name><![CDATA[f_setResidentialBatteries]]></Name>
 		<X>90</X>
-		<Y>1000</Y>
+		<Y>1060</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -243,7 +243,7 @@
 		<Name><![CDATA[f_setGridBatteries]]></Name>
 		<Description><![CDATA[Passing a list of gcs sets all gcs to the same input value.]]></Description>
 		<X>90</X>
-		<Y>980</Y>
+		<Y>1040</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -395,7 +395,7 @@
 		<Id>1754986167346</Id>
 		<Name><![CDATA[f_setCurtailment]]></Name>
 		<X>70</X>
-		<Y>900</Y>
+		<Y>920</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -454,8 +454,8 @@
 		<ReturnType>J_ProfilePointer</ReturnType>
 		<Id>1773764103422</Id>
 		<Name><![CDATA[f_getPVTProfilePointer]]></Name>
-		<X>400</X>
-		<Y>790</Y>
+		<X>90</X>
+		<Y>800</Y>
 		<Label>
 			<X>12</X>
 			<Y>1</Y>
@@ -466,6 +466,10 @@
 		<Parameter>
 			<Name><![CDATA[pvtOrientation]]></Name>
 			<Type><![CDATA[OL_PVOrientation]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[gridConnectionID]]></Name>
+			<Type><![CDATA[String]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>

--- a/_alp/Agents/tabElectricity/Code/Functions.xml
+++ b/_alp/Agents/tabElectricity/Code/Functions.xml
@@ -449,4 +449,24 @@
 		<ShowLabel>true</ShowLabel>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
+	<Function AccessType="public" StaticFunction="false">
+		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+		<ReturnType>J_ProfilePointer</ReturnType>
+		<Id>1773764103422</Id>
+		<Name><![CDATA[f_getPVTProfilePointer]]></Name>
+		<X>400</X>
+		<Y>790</Y>
+		<Label>
+			<X>12</X>
+			<Y>1</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[pvtOrientation]]></Name>
+			<Type><![CDATA[OL_PVOrientation]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
 </Functions>

--- a/_alp/Agents/tabElectricity/Levels/Level.level.xml
+++ b/_alp/Agents/tabElectricity/Levels/Level.level.xml
@@ -911,7 +911,7 @@ f_setGridBatteries(sl_collectiveBattery_MWh_default.getValue() * 1000, gcListGri
 		<LineMaterial>null</LineMaterial>
 		<LineStyle>SOLID</LineStyle>
 		<Width>310</Width>
-		<Height>250</Height>
+		<Height>290</Height>
 		<Rotation>0.0</Rotation>
 		<FillColor>-1</FillColor>
 		<FillMaterial>null</FillMaterial>
@@ -3076,7 +3076,7 @@ zero_Interface.f_setTrafoText();
 		<Id>1754985710083</Id>
 		<Name><![CDATA[rect_batteryFunctions]]></Name>
 		<X>39</X>
-		<Y>931</Y>
+		<Y>991</Y>
 		<Label>
 			<X>10</X>
 			<Y>10</Y>
@@ -3102,7 +3102,7 @@ zero_Interface.f_setTrafoText();
 		<Id>1754985710085</Id>
 		<Name><![CDATA[t_batteryFunctionsDescription]]></Name>
 		<X>189</X>
-		<Y>936</Y>
+		<Y>996</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>

--- a/_alp/Classes/Class.Building_data.java
+++ b/_alp/Classes/Class.Building_data.java
@@ -27,6 +27,8 @@ public class Building_data {
 	Double gas_consumption_m3pa;
 	Double pv_installed_kwp;
 	Double pv_potential_kwp;
+	OL_Orientation roof_orientation;
+	double roof_pitch_deg;
 	OL_GridConnectionEnergyLabel energy_label;
 	Boolean has_private_parking;
 	String gridnode_id;

--- a/_alp/Classes/Class.Building_data.java
+++ b/_alp/Classes/Class.Building_data.java
@@ -27,8 +27,7 @@ public class Building_data {
 	Double gas_consumption_m3pa;
 	Double pv_installed_kwp;
 	Double pv_potential_kwp;
-	OL_Orientation roof_orientation;
-	double roof_pitch_deg;
+	OL_PVOrientation pv_orientation;
 	OL_GridConnectionEnergyLabel energy_label;
 	Boolean has_private_parking;
 	String gridnode_id;

--- a/_alp/Classes/Class.J_scenario_Current.java
+++ b/_alp/Classes/Class.J_scenario_Current.java
@@ -34,7 +34,7 @@ public class J_scenario_Current implements Serializable {
 	private Double currentContractFeedinCapacity_kW = 0.0;
 	private Double currentPhysicalConnectionCapacity_kW = 0.0;
 	private Integer currentPV_kW = 0;
-	//String currentPV_orient;
+	private OL_PVOrientation currentPV_orientation;
 	private Float currentWind_kW = 0f;
 	private Float currentBatteryPower_kW = 0f;
 	private Float currentBatteryCapacity_kWh = 0f;
@@ -92,11 +92,11 @@ public class J_scenario_Current implements Serializable {
     	this.currentPV_kW = currentPV_kW;
     }
     
-    /*
-    public void setCurrentPV_orient(String currentPV_orient) {
-        this.currentPV_orient = currentPV_orient;
+    
+    public void setCurrentPV_orientation(OL_PVOrientation currentPV_orientation) {
+        this.currentPV_orientation = currentPV_orientation;
     }
-	*/
+	
     public void setCurrentWind_kW(Float currentWind_kW) {
         this.currentWind_kW = currentWind_kW;
     }
@@ -190,11 +190,9 @@ public class J_scenario_Current implements Serializable {
         return currentPV_kW;
     }
     
-    /*
-    public String getCurrentPV_orient() {
-        return currentPV_orient;
+    public OL_PVOrientation getCurrentPV_orientation() {
+        return this.currentPV_orientation;
     }
-	*/
     
     public Float getCurrentWind_kW() {
         return currentWind_kW;

--- a/_alp/Classes/Class.J_scenario_Future.java
+++ b/_alp/Classes/Class.J_scenario_Future.java
@@ -39,6 +39,7 @@ public class J_scenario_Future implements Serializable {
 	private boolean plannedCurtailment = false;
 	private Integer plannedPV_kW = 0;
 	private Integer plannedPV_year;
+	private OL_PVOrientation plannedPV_orientation;
 	private Float plannedWind_kW = 0f;
 	private Float plannedBatteryPower_kW = 0f;
 	private Float plannedBatteryCapacity_kWh = 0f;
@@ -111,7 +112,11 @@ public class J_scenario_Future implements Serializable {
     public void setPlannedPV_year(Integer plannedPV_year) {
         this.plannedPV_year = plannedPV_year;
     }
-
+    
+    public void setPlannedPV_orientation(OL_PVOrientation plannedPV_orientation) {
+        this.plannedPV_orientation = plannedPV_orientation;
+    }
+    
     public void setPlannedWind_kW(Float plannedWind_kW) {
         this.plannedWind_kW = plannedWind_kW;
     }
@@ -200,6 +205,10 @@ public class J_scenario_Future implements Serializable {
         return plannedPV_year;
     }
 
+    public OL_PVOrientation getPlannedPV_orientation() {
+        return this.plannedPV_orientation;
+    }
+    
     public Float getPlannedWind_kW() {
         return plannedWind_kW;
     }

--- a/_alp/Classes/Class.Solarfarm_data.java
+++ b/_alp/Classes/Class.Solarfarm_data.java
@@ -17,6 +17,8 @@ public class Solarfarm_data {
 		String city;
 		String gridnode_id;
 		boolean initially_active;
+		OL_Orientation orientation;
+		double tilt_angle_deg;
 		boolean isSliderGC;
 		double capacity_electric_kw;
 		double connection_capacity_kw;

--- a/_alp/Classes/Class.Solarfarm_data.java
+++ b/_alp/Classes/Class.Solarfarm_data.java
@@ -17,8 +17,7 @@ public class Solarfarm_data {
 		String city;
 		String gridnode_id;
 		boolean initially_active;
-		OL_Orientation orientation;
-		double tilt_angle_deg;
+		OL_PVOrientation orientation;
 		boolean isSliderGC;
 		double capacity_electric_kw;
 		double connection_capacity_kw;


### PR DESCRIPTION
Added functionality to change orientation per solarfarm and building in excel sheets. Related to https://github.com/Zenmo/zero_engine/compare/Building-PV-roof-orientation-+-angle?expand=1

Separated f_addEnergyProduction into individual add windmill, PV, and PT functions.
Added f_getPVTProfilePointer to get the correct ProfilePointer from the energymodel.
Added OL_PVOrientation; Only options are (currently) SOUTH and EASTWEST

TODO:
- @ThyVonR Can you add the column "pv_orientation" to QGIS when creating the buildings excel? Standardly, each building should have "SOUTH" assigned to them.
- After pull-request: update LUX_ProjectTemplate excel files + f_buildingRecordBuilder and f_setSolarfarm_data in AnyLogic.


-> Merge together with https://github.com/Zenmo/zero_engine/pull/278 