### PR TITLE
Use our own URL for GIS tiles

### DIFF
--- a/_alp/Agents/Zero_Interface/Levels/Level.level.xml
+++ b/_alp/Agents/Zero_Interface/Levels/Level.level.xml
@@ -1999,8 +1999,8 @@ else{
 		<BorderColor>-4144960</BorderColor>
 		<FillColor>-1</FillColor>
 		<ShowTiles>true</ShowTiles>
-		<CustomTileURL>false</CustomTileURL>
-		<TileURL>https://a.tile.openstreetmap.org/[zoom]/[x]/[y].png</TileURL>
+		<CustomTileURL>true</CustomTileURL>
+		<TileURL>https://gistiles.lux.energy/maptiler-base-v4-hdpi/[zoom]/[x]/[y].png</TileURL>
 		<RouteProviderType>WEB_SERVICE</RouteProviderType>
 		<RouteNotFound>CREATE_STRAIGHT_LINE</RouteNotFound>
 		<TransportType>CAR</TransportType>


### PR DESCRIPTION
I tested this in a demo on the cloud model and it works.

Closes #185 