### PR TITLE
Loader: setSimulationTimeParameters public

### DIFF
--- a/_alp/Agents/Zero_Loader/Code/Functions.xml
+++ b/_alp/Agents/Zero_Loader/Code/Functions.xml
@@ -2409,7 +2409,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="default" StaticFunction="false">
+	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1758714675284</Id>


### PR DESCRIPTION
So that it can be reused by ESDL initialization.