### PR TITLE
Loader: remove unnecessary zero_interface dereferencing

### DIFF
--- a/_alp/Agents/Zero_Loader/Code/Functions.java
+++ b/_alp/Agents/Zero_Loader/Code/Functions.java
@@ -2827,7 +2827,7 @@ switch (heatAssetType){ // There is always only one heatingType, If there are ma
 		//Add primary heating asset (heatpump) (if its not part of the basic profile already
 		inputCapacityElectric_kW = max(avgc_data.p_minHeatpumpElectricCapacity_kW, maxHeatOutputPower_kW / 3); //-- /3, kan nog kleiner want is hybride zodat gasbrander ook bij springt, dus kleiner MOETEN aanname voor hoe klein onderzoeken
 		efficiency = avgc_data.p_avgEfficiencyHeatpump_fr;
-		baseTemperature_degC = zero_Interface.energyModel.pp_ambientTemperature_degC.getCurrentValue();
+		baseTemperature_degC = energyModel.pp_ambientTemperature_degC.getCurrentValue();
 		outputTemperature_degC = avgc_data.p_avgOutputTemperatureHybridHeatpump_degC;
 		ambientTempType = OL_AmbientTempType.AMBIENT_AIR;
 		sourceAssetHeatPower_kW = 0;
@@ -2835,7 +2835,7 @@ switch (heatAssetType){ // There is always only one heatingType, If there are ma
 		
 		J_EAConversionHeatPump heatPumpHybrid = new J_EAConversionHeatPump(parentGC, inputCapacityElectric_kW, efficiency, energyModel.p_timeParameters, outputTemperature_degC, baseTemperature_degC, sourceAssetHeatPower_kW, belowZeroHeatpumpEtaReductionFactor, ambientTempType);
 
-		zero_Interface.energyModel.c_ambientDependentAssets.add(heatPumpHybrid);
+		energyModel.c_ambientDependentAssets.add(heatPumpHybrid);
 		
 		//Add secondary heating asset (gasburner)
 		heatOutputCapacityGasBurner_kW = max(avgc_data.p_minGasBurnerOutputCapacity_kW, maxHeatOutputPower_kW);
@@ -2849,7 +2849,7 @@ switch (heatAssetType){ // There is always only one heatingType, If there are ma
 		//Add primary heating asset (heatpump)
 		inputCapacityElectric_kW = max(avgc_data.p_minHeatpumpElectricCapacity_kW, maxHeatOutputPower_kW); // Could be a lot smaller due to high cop
 		efficiency = avgc_data.p_avgEfficiencyHeatpump_fr;
-		baseTemperature_degC = zero_Interface.energyModel.pp_ambientTemperature_degC.getCurrentValue();
+		baseTemperature_degC = energyModel.pp_ambientTemperature_degC.getCurrentValue();
 		outputTemperature_degC = avgc_data.p_avgOutputTemperatureElectricHeatpump_degC;
 		ambientTempType = OL_AmbientTempType.AMBIENT_AIR;
 		sourceAssetHeatPower_kW = 0;
@@ -4538,7 +4538,7 @@ zero_Interface.c_scenarioMap_Future = saveObject.c_scenarioMap_Future;
 
 
 /*
-List<ConnectionOwner> c_COCompanies = findAll(zero_Interface.energyModel.pop_connectionOwners, p -> p.p_connectionOwnerType == OL_ConnectionOwnerType.COMPANY); 
+List<ConnectionOwner> c_COCompanies = findAll(energyModel.pop_connectionOwners, p -> p.p_connectionOwnerType == OL_ConnectionOwnerType.COMPANY); 
 
 
 int i = 0;
@@ -4686,9 +4686,9 @@ traceln("Loading modelSave...");
 //pauseSimulation();
 
 // Collect GIS_Objects into hashmap, to link to new EnergyModel.
-zero_Interface.energyModel.pop_GIS_Buildings.forEach(x->{c_GISregions.put(x.p_id, x.gisRegion);});
-zero_Interface.energyModel.pop_GIS_Objects.forEach(x->{c_GISregions.put(x.p_id, x.gisRegion);});
-zero_Interface.energyModel.pop_GIS_Parcels.forEach(x->{c_GISregions.put(x.p_id, x.gisRegion);});
+energyModel.pop_GIS_Buildings.forEach(x->{c_GISregions.put(x.p_id, x.gisRegion);});
+energyModel.pop_GIS_Objects.forEach(x->{c_GISregions.put(x.p_id, x.gisRegion);});
+energyModel.pop_GIS_Parcels.forEach(x->{c_GISregions.put(x.p_id, x.gisRegion);});
 pauseSimulation();
 try {
 	v_objectMapper = new ObjectMapper();
@@ -4737,7 +4737,7 @@ try {
 	// get heatingTypeHashmap from 'old' energyModel.
 	deserializedEnergyModel.c_defaultHeatingStrategies = zero_Interface.energyModel.c_defaultHeatingStrategies;
 	
-	zero_Interface.zero_loader.energyModel = deserializedEnergyModel;
+	this.energyModel = deserializedEnergyModel;
 	zero_Interface.energyModel = deserializedEnergyModel;
 	zero_Interface.uI_Results.energyModel = deserializedEnergyModel;
 	uI_Results.energyModel = deserializedEnergyModel;

--- a/_alp/Agents/Zero_Loader/Levels/Level.level.xml
+++ b/_alp/Agents/Zero_Loader/Levels/Level.level.xml
@@ -1191,13 +1191,13 @@ try {
 	
 	// Get profilePointer tableFunctions from 'original' energyModel
 	deserializedEnergyModel.c_profiles.forEach(x-&gt;{
-		J_ProfilePointer origProfile = zero_Interface.energyModel.f_findProfile(x.name);
+		J_ProfilePointer origProfile = energyModel.f_findProfile(x.name);
 		x.setTableFunction(origProfile.getTableFunction());
 	});
 	// get heatingTypeHashmap from 'old' energyModel.
-	deserializedEnergyModel.c_defaultHeatingStrategies = zero_Interface.energyModel.c_defaultHeatingStrategies;
+	deserializedEnergyModel.c_defaultHeatingStrategies = energyModel.c_defaultHeatingStrategies;
 	
-	energyModel = deserializedEnergyModel;
+	this.energyModel = deserializedEnergyModel;
 	zero_Interface.energyModel = deserializedEnergyModel;
 	zero_Interface.uI_Results.energyModel = deserializedEnergyModel;
 	//zero_Interface.f_clearSelectionAndSelectEnergyModel();


### PR DESCRIPTION
So that it's easier to use the loader without the interface.