### PR TITLE
addBuildingHeadModel public for ESDL loader

### DIFF
--- a/_alp/Agents/Zero_Loader/Code/Functions.xml
+++ b/_alp/Agents/Zero_Loader/Code/Functions.xml
@@ -1366,7 +1366,7 @@ verbruik = levering + productie - teruglevering]]></Description>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
-	<Function AccessType="protected" StaticFunction="false">
+	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1749727623536</Id>


### PR DESCRIPTION
So it can be reused.