### PR TITLE
LossFactor was not scaled with floor area

### DIFF
--- a/_alp/Agents/Zero_Loader/Code/Functions.java
+++ b/_alp/Agents/Zero_Loader/Code/Functions.java
@@ -3312,7 +3312,7 @@ else{
 			lossFactor_WpK = uniform (avgc_data.map_insulationLabel_lossfactorPerFloorSurface_WpKm2.get(OL_GridConnectionInsulationLabel.B), avgc_data.map_insulationLabel_lossfactorPerFloorSurface_WpKm2.get(OL_GridConnectionInsulationLabel.G)) * floorArea_m2;
 			break;
 		default:
-			lossFactor_WpK = avgc_data.map_insulationLabel_lossfactorPerFloorSurface_WpKm2.get(parentGC.p_insulationLabel);
+			lossFactor_WpK = avgc_data.map_insulationLabel_lossfactorPerFloorSurface_WpKm2.get(parentGC.p_insulationLabel) * floorArea_m2;
 	}
 }
 


### PR DESCRIPTION
In f_addBuildingHeatModel when a building did not have the annual heat demand specified, but did have the energy/insulation label it forgot to scale with the floor area!